### PR TITLE
Long term credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ An alternative option is to set it in a `.env` file, [pipenv loads .env into env
 
 1. `echo GOCARDLESS_SECRET_ID=SecretIdFromGoCardless >.env`
 1. `echo GOCARDLESS_SECRET_KEY=SecretKeyFromGoCardless >>.env`
+1. `echo TOKEN_DISK_PATH_PREFIX=/path/to/token/folder >>.env`
+1. `echo REQUISITION_DISK_PATH_PREFIX=/path/to/token/folder >>.env`
 1. `pipenv run <command> <arguments>`
 
 ## Developing

--- a/personal_finances/bank_interface/client.py
+++ b/personal_finances/bank_interface/client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from nordigen import NordigenClient
 import time
 from dataclasses import dataclass
-from typing import List, Callable, Any, Dict, Iterable, Type, Optional, cast
+from typing import Dict, List, Callable, Any, Iterable, Type, Optional, cast
 from types import TracebackType
 import webbrowser
 from functools import reduce
@@ -12,9 +12,27 @@ import signal
 import requests
 import logging
 
+from .disk_requisition_store import DiskRequisitionStore
+from personal_finances.bank_interface.nordigen_adapter import (
+    EMPTY_NORDIGEN_TRANSACTIONS,
+    NordigenTransactions,
+    concat_nordigen_transactions,
+)
+from personal_finances.bank_interface.requisition_store import (
+    GocardlessRequisitionValidator,
+    Requisitions,
+    gocardless_requisition_adapter,
+)
+from .disk_token_store import DiskTokenStore
+from .token_store import (
+    GocardlessAccessToken,
+    gocardless_token_adapter,
+    gocardless_update_access_token,
+)
+
 
 LOGGER = logging.getLogger(__name__)
-NordigenSession = Any
+NordigenRequisition = Any
 
 
 @dataclass
@@ -36,17 +54,24 @@ def log_wrapper(func: Callable, *args: Any, **kwargs: Any) -> Any:
     return response
 
 
-EMPTY_TRANSACTIONS: Dict[str, List] = {"booked": [], "pending": []}
+# Warning: the application does not support multiple users, however some features
+#          do support it and this temporary variable is used across features
+#          supporing multiple users.
+TEMPORARY_FIXED_USER_ID = "temporary-user-id"
 
 
 class BankClient:
     def __init__(self, auth: NordigenAuth, bank_details: List[BankDetails]):
-        self.bank_details = bank_details
+        self._bank_details = bank_details
         self._nordigen_client = NordigenClient(
             secret_id=auth.secret_id,
             secret_key=auth.secret_key,
         )
-        self._token = log_wrapper(self._nordigen_client.generate_token)
+        self._token_store = DiskTokenStore()
+        self._requisition_store = DiskRequisitionStore()
+
+        self._handle_tokens()
+
         LOGGER.info("client initialized")
 
     def __enter__(self) -> BankClient:
@@ -69,14 +94,40 @@ class BankClient:
         )
         LOGGER.info("uvicorn server killed")
 
-    def _create_bank_sessions(self) -> Iterable[NordigenSession]:
+    def _handle_tokens(self) -> None:
+        if self._token_store.is_access_token_valid(TEMPORARY_FIXED_USER_ID):
+            LOGGER.info("valid access token found")
+            self._nordigen_client.token = self._token_store.get_last_token(
+                TEMPORARY_FIXED_USER_ID
+            ).AccessToken
+
+        elif self._token_store.is_refresh_token_valid(TEMPORARY_FIXED_USER_ID):
+            LOGGER.info("valid refresh token found")
+            last_token = self._token_store.get_last_token(TEMPORARY_FIXED_USER_ID)
+            new_access_token = self._nordigen_client.exchange_token(
+                last_token.RefreshToken
+            )
+            updated_token = gocardless_update_access_token(
+                GocardlessAccessToken(**cast(Dict, new_access_token)), last_token
+            )
+            self._token_store.save_token(TEMPORARY_FIXED_USER_ID, updated_token)
+        else:
+            LOGGER.info("no valid token found - generating new token")
+            # Users are prompted with URLs to authorize their bank data
+            new_token = log_wrapper(self._nordigen_client.generate_token)
+            new_token_object = gocardless_token_adapter(new_token)
+
+            self._nordigen_client.token = new_token_object.AccessToken
+            self._token_store.save_token(TEMPORARY_FIXED_USER_ID, new_token_object)
+
+    def _create_bank_requisitions(self) -> Iterable[NordigenRequisition]:
         institution_ids: Iterable[Any] = map(
             lambda bank_details: log_wrapper(
                 self._nordigen_client.institution.get_institution_id_by_name,
                 country=bank_details.country,
                 institution=bank_details.name,
             ),
-            self.bank_details,
+            self._bank_details,
         )
 
         return map(
@@ -89,21 +140,23 @@ class BankClient:
             institution_ids,
         )
 
-    def _authorize_session(self, session: NordigenSession) -> None:
-        webbrowser.open(session.link)
+    def _authorize_requisition(self, requisition: NordigenRequisition) -> None:
+        webbrowser.open(requisition.link)
 
     def _verify_authorizations(self) -> None:
         validations: List[str] = []
 
         # TODO: validate content, not only length
-        while len(validations) < len(self.bank_details):
+        while len(validations) < len(self._bank_details):
             validations = requests.get(
                 "http://127.0.0.1:8000/validations/", verify=False
             ).json()
             LOGGER.info(validations)
             time.sleep(1)
 
-    def _get_transactions_for_requisition(self, requisition_id: str) -> Dict[str, List]:
+    def _get_transactions_for_requisition(
+        self, requisition_id: str
+    ) -> NordigenTransactions:
         LOGGER.info(f"getting transactions for requisition {requisition_id}")
         accounts = log_wrapper(
             self._nordigen_client.requisition.get_requisition_by_id,
@@ -111,32 +164,58 @@ class BankClient:
         )
 
         if len(accounts["accounts"]) == 0:
-            return EMPTY_TRANSACTIONS
+            return EMPTY_NORDIGEN_TRANSACTIONS
 
-        account_id = accounts["accounts"][0]
-        account = log_wrapper(self._nordigen_client.account_api, id=account_id)
-        transactions = log_wrapper(account.get_transactions)
-        return cast(Dict[str, List], transactions["transactions"])
-
-    def get_transactions(self) -> Dict[str, List]:
-        sessions = list(self._create_bank_sessions())
-        for session in sessions:
-            self._authorize_session(session)
-
-        self._verify_authorizations()
-
-        LOGGER.info(sessions)
-
-        return reduce(
-            lambda all_transactons, transactions: {
-                "booked": all_transactons["booked"] + transactions["booked"],
-                "pending": all_transactons["pending"] + transactions["pending"],
-            },
-            map(
-                lambda session: self._get_transactions_for_requisition(
-                    session.requisition_id
-                ),
-                sessions,
+        account_ids = accounts["accounts"]
+        accounts = map(
+            lambda account_id: log_wrapper(
+                self._nordigen_client.account_api, id=account_id
             ),
-            EMPTY_TRANSACTIONS,
+            account_ids,
+        )
+        return reduce(
+            concat_nordigen_transactions,
+            map(
+                lambda account: log_wrapper(account.get_transactions)["transactions"],
+                accounts,
+            ),
+            EMPTY_NORDIGEN_TRANSACTIONS,
+        )
+
+    def _get_requisitions(self) -> Requisitions:
+        requisition_validator = GocardlessRequisitionValidator(
+            self._nordigen_client.requisition
+        )
+
+        if self._requisition_store.are_all_requisition_valid(
+            TEMPORARY_FIXED_USER_ID, requisition_validator
+        ):
+            return self._requisition_store.get_last_requisitions(
+                TEMPORARY_FIXED_USER_ID
+            )
+        else:
+            requisitions = list(self._create_bank_requisitions())
+            for requisition in requisitions:
+                self._authorize_requisition(requisition)
+
+            self._verify_authorizations()
+
+            LOGGER.info(requisitions)
+
+            parsed_requisitions = gocardless_requisition_adapter(requisitions)
+            self._requisition_store.save_requisitions(
+                TEMPORARY_FIXED_USER_ID, parsed_requisitions
+            )
+            return parsed_requisitions
+
+    def get_transactions(self) -> NordigenTransactions:
+        return reduce(
+            concat_nordigen_transactions,
+            map(
+                lambda requisitionId: self._get_transactions_for_requisition(
+                    requisitionId
+                ),
+                self._get_requisitions().RequisitionIds,
+            ),
+            EMPTY_NORDIGEN_TRANSACTIONS,
         )

--- a/personal_finances/bank_interface/disk_requisition_store.py
+++ b/personal_finances/bank_interface/disk_requisition_store.py
@@ -1,0 +1,50 @@
+from personal_finances.bank_interface.key_value_disk_store import (
+    KeyValueDiskStore,
+    ValueNotFound,
+)
+from .requisition_store import EMPTY_REQUISITIONS, RequisitionStore, Requisitions
+import json
+import logging
+from pydantic import ValidationError
+import os
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class RequisitionAbsolutePathNotConfigured(Exception):
+    pass
+
+
+def _get_path_from_env() -> str:
+    try:
+        return os.environ["REQUISITION_DISK_PATH_PREFIX"]
+    except KeyError as e:
+        raise RequisitionAbsolutePathNotConfigured(e)
+
+
+class DiskRequisitionStore(RequisitionStore):
+    disk_store: KeyValueDiskStore
+
+    def __init__(self) -> None:
+        self.disk_store = KeyValueDiskStore(_get_path_from_env())
+
+    def save_requisitions(
+        self, user_id: str, requisition: Requisitions
+    ) -> Requisitions:
+        previous_content = self.disk_store.write_to_disk(
+            f"{user_id}.json", requisition.model_dump_json()
+        )
+        try:
+            return Requisitions.model_validate_json(previous_content)
+        except (json.JSONDecodeError, ValidationError) as e:
+            LOGGER.warning("error decoding json from requisition: " + str(e))
+            return EMPTY_REQUISITIONS
+
+    def get_last_requisitions(self, user_id: str) -> Requisitions:
+        try:
+            return Requisitions.model_validate_json(
+                self.disk_store.read_from_disk(f"{user_id}.json")
+            )
+        except ValueNotFound:
+            return EMPTY_REQUISITIONS

--- a/personal_finances/bank_interface/disk_token_store.py
+++ b/personal_finances/bank_interface/disk_token_store.py
@@ -1,0 +1,52 @@
+from personal_finances.bank_interface.key_value_disk_store import (
+    KeyValueDiskStore,
+    ValueNotFound,
+)
+from .token_store import TokenStore, TokenObject
+from typing import Optional
+import json
+import logging
+from .token_store import TokenNotFound
+from pydantic import ValidationError
+import os
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TokenAbsolutePathNotConfigured(Exception):
+    pass
+
+
+def _get_path_from_env() -> str:
+    try:
+        return os.environ["TOKEN_DISK_PATH_PREFIX"]
+    except KeyError as e:
+        raise TokenAbsolutePathNotConfigured(e)
+
+
+class DiskTokenStore(TokenStore):
+    disk_store: KeyValueDiskStore
+
+    def __init__(self) -> None:
+        self.disk_store = KeyValueDiskStore(_get_path_from_env())
+
+    def save_token(self, user_id: str, token: TokenObject) -> Optional[TokenObject]:
+        previous_content = self.disk_store.write_to_disk(
+            f"{user_id}.json", token.model_dump_json()
+        )
+        try:
+            previous_token = TokenObject.model_validate_json(previous_content)
+        except (json.JSONDecodeError, ValidationError) as e:
+            LOGGER.warning("error decoding json from token: " + str(e))
+            previous_token = None
+
+        return previous_token
+
+    def get_last_token(self, user_id: str) -> TokenObject:
+        try:
+            return TokenObject.model_validate_json(
+                self.disk_store.read_from_disk(f"{user_id}.json")
+            )
+        except ValueNotFound as e:
+            raise TokenNotFound from e

--- a/personal_finances/bank_interface/key_value_disk_store.py
+++ b/personal_finances/bank_interface/key_value_disk_store.py
@@ -1,0 +1,51 @@
+import os
+from personal_finances.file_helper import write_string
+
+
+class InvalidAbsolutePath(Exception):
+    pass
+
+
+class ValueNotFound(Exception):
+    pass
+
+
+class KeyValueDiskStore:
+    path_prefix: str
+
+    def __init__(self, store_path_prefix: str) -> None:
+        self.path_prefix = self._get_disk_path_prefix(store_path_prefix)
+
+    def _remove_trailing_char(self, input_string: str, trailing_char: str) -> str:
+        return input_string[:-1] if input_string[-1] == trailing_char else input_string
+
+    def _contains_empty_path_part(self, absolute_path: str) -> bool:
+        return any(map(lambda path_part: path_part == "", absolute_path[1:].split("/")))
+
+    def _get_disk_path_prefix(self, configured_path_prefix: str) -> str:
+        if not os.path.isabs(configured_path_prefix):
+            raise InvalidAbsolutePath(f"is not absolute path: {configured_path_prefix}")
+
+        path_without_trailing_slash = self._remove_trailing_char(
+            configured_path_prefix, "/"
+        )
+
+        if self._contains_empty_path_part(path_without_trailing_slash):
+            raise InvalidAbsolutePath(
+                f"contains empty path parts: {configured_path_prefix}"
+            )
+
+        return path_without_trailing_slash
+
+    def write_to_disk(self, key: str, value: str) -> str:
+        return write_string(
+            f"{self.path_prefix}/{key}",
+            value,
+        )
+
+    def read_from_disk(self, key: str) -> str:
+        try:
+            with open(f"{self.path_prefix}/{key}", "r") as value_file:
+                return value_file.read()
+        except Exception as e:
+            raise ValueNotFound(e)

--- a/personal_finances/bank_interface/nordigen_adapter.py
+++ b/personal_finances/bank_interface/nordigen_adapter.py
@@ -15,8 +15,9 @@ class TransactionAmount(TypedDict):
 
 
 class NordigenTransaction(TypedDict):
-    bookingDatetime: str
-    bookingDate: str
+    # Either bookingDatetime or bookingDate
+    bookingDatetime: NotRequired[str]
+    bookingDate: NotRequired[str]
     internalTransactionId: NotRequired[str]
     transactionAmount: TransactionAmount
     transactionId: NotRequired[str]
@@ -31,6 +32,18 @@ class NordigenTransaction(TypedDict):
 class NordigenTransactions(TypedDict):
     booked: List[NordigenTransaction]
     pending: List[NordigenTransaction]
+
+
+EMPTY_NORDIGEN_TRANSACTIONS: NordigenTransactions = {"booked": [], "pending": []}
+
+
+def concat_nordigen_transactions(
+    first: NordigenTransactions, second: NordigenTransactions
+) -> NordigenTransactions:
+    return {
+        "booked": first["booked"] + second["booked"],
+        "pending": first["pending"] + second["pending"],
+    }
 
 
 def as_simple_transaction(transaction: NordigenTransaction) -> SimpleTransaction:

--- a/personal_finances/bank_interface/requisition_store.py
+++ b/personal_finances/bank_interface/requisition_store.py
@@ -1,0 +1,78 @@
+from abc import ABC, abstractmethod
+from nordigen.api import RequisitionsApi
+from nordigen.types import RequisitionDto
+from pydantic import BaseModel
+from typing import List, cast
+
+
+class Requisitions(BaseModel):
+    RequisitionIds: List[str]
+
+
+EMPTY_REQUISITIONS: Requisitions = Requisitions(RequisitionIds=[])
+
+
+def gocardless_requisition_adapter(requisitions: List[RequisitionDto]) -> Requisitions:
+    return Requisitions.model_validate(
+        {
+            "RequisitionIds": [
+                gocardless_requisition.requisition_id
+                for gocardless_requisition in requisitions
+            ]
+        }
+    )
+
+
+class RequisitionValidator(ABC):
+    @abstractmethod
+    def is_requisition_valid(self, requisition_id: str) -> bool:
+        """
+        An interface to validate requisitions
+        """
+        pass
+
+
+class GocardlessRequisitionValidator(RequisitionValidator):
+    requisition_client: RequisitionsApi
+
+    def __init__(self, requistion_client: RequisitionsApi):
+        self.requisition_client = requistion_client
+
+    def is_requisition_valid(self, requisition_id: str) -> bool:
+        # https://developer.gocardless.com/bank-account-data/statuses
+        return cast(
+            bool,
+            self.requisition_client.get_requisition_by_id(requisition_id)["status"]
+            == "LN",
+        )
+
+
+class RequisitionStore(ABC):
+    @abstractmethod
+    def save_requisitions(
+        self, user_id: str, requisition: Requisitions
+    ) -> Requisitions:
+        """
+        Saves the new requisition and returns the older one
+        """
+        pass
+
+    @abstractmethod
+    def get_last_requisitions(self, user_id: str) -> Requisitions:
+        """
+        Retrieves the last requisition from the store for a given user id
+        """
+        pass
+
+    def are_all_requisition_valid(
+        self, user_id: str, validator: RequisitionValidator
+    ) -> bool:
+        last_requisitions = self.get_last_requisitions(user_id)
+
+        if len(last_requisitions.RequisitionIds) == 0:
+            return False
+
+        return all(
+            validator.is_requisition_valid(requisition_id)
+            for requisition_id in last_requisitions.RequisitionIds
+        )

--- a/personal_finances/bank_interface/token_store.py
+++ b/personal_finances/bank_interface/token_store.py
@@ -1,0 +1,86 @@
+from abc import ABC, abstractmethod
+from copy import deepcopy
+from pydantic import BaseModel
+from datetime import datetime
+from typing import Optional
+from nordigen.types import TokenType
+
+
+class TokenObject(BaseModel):
+    AccessToken: str
+    AccessExpires: int
+    RefreshToken: str
+    RefreshExpires: int
+    CreationEpoch: int
+    AccessRefreshEpoch: int
+
+
+class GocardlessAccessToken(BaseModel):
+    access: str
+    access_expires: int
+
+
+def gocardless_token_adapter(gocardless_token: TokenType) -> TokenObject:
+    token_dict = {
+        "AccessToken": gocardless_token["access"],
+        "AccessExpires": gocardless_token["access_expires"],
+        "RefreshToken": gocardless_token["refresh"],
+        "RefreshExpires": gocardless_token["refresh_expires"],
+        "CreationEpoch": int(datetime.now().timestamp()),
+        "AccessRefreshEpoch": int(datetime.now().timestamp()),
+    }
+    return TokenObject.model_validate(token_dict)
+
+
+def gocardless_update_access_token(
+    access_token: GocardlessAccessToken, existing_token_object: TokenObject
+) -> TokenObject:
+    new_token_object = deepcopy(existing_token_object)
+    new_token_object.AccessToken = access_token.access
+    new_token_object.AccessExpires = access_token.access_expires
+    new_token_object.AccessRefreshEpoch = int(datetime.now().timestamp())
+    return new_token_object
+
+
+class TokenNotFound(Exception):
+    pass
+
+
+class TokenStore(ABC):
+    @abstractmethod
+    def save_token(self, user_id: str, token: TokenObject) -> Optional[TokenObject]:
+        """
+        Saves the new token and returns the older one
+        """
+        pass
+
+    @abstractmethod
+    def get_last_token(self, user_id: str) -> TokenObject:
+        """
+        Retrieves the last token from the store for a given user id
+        """
+        pass
+
+    def is_access_token_valid(self, user_id: str) -> bool:
+        """
+        Checks whether the access token is not expired
+        """
+        try:
+            last_token = self.get_last_token(user_id)
+        except TokenNotFound:
+            return False
+
+        now_epoch = int(datetime.now().timestamp())
+        return (last_token.AccessRefreshEpoch + last_token.AccessExpires) > now_epoch
+
+    def is_refresh_token_valid(self, user_id: str) -> bool:
+        """
+        Checks whether the refresh token is not expired
+        """
+        try:
+            last_token = self.get_last_token(user_id)
+        except TokenNotFound:
+            return False
+
+        now_epoch = int(datetime.now().timestamp())
+        return (last_token.CreationEpoch + last_token.RefreshExpires) > now_epoch

--- a/personal_finances/file_helper.py
+++ b/personal_finances/file_helper.py
@@ -18,3 +18,13 @@ def write_json(
     create_dirs(path)
     with open(path, "w") as o_file:
         o_file.write(json.dumps(content, indent=4, default=json_converter))
+
+
+def write_string(
+    path: str, content: str, json_converter: Optional[Callable] = str
+) -> str:
+    create_dirs(path)
+    with open(path, "w+") as o_file:
+        previous_content = o_file.read()
+        o_file.write(content)
+        return previous_content

--- a/tests/bank_interface/test_client.py
+++ b/tests/bank_interface/test_client.py
@@ -5,16 +5,27 @@ from personal_finances.bank_interface.client import (
     BankDetails,
     NordigenAuth,
 )
+from personal_finances.bank_interface.requisition_store import (
+    GocardlessRequisitionValidator,
+    Requisitions,
+)
+from personal_finances.bank_interface.token_store import TokenObject
 import signal
 from nordigen.types import RequisitionDto
-from typing import Generator
+from typing import Dict, Generator, cast
+
+
+@fixture(autouse=True)
+def token_now_mock() -> Generator[Mock, None, None]:
+    with patch("personal_finances.bank_interface.token_store.datetime") as m:
+        m.now.return_value.timestamp.return_value = 321
+        yield m
 
 
 @fixture(autouse=True)
 def nordigen_client_mock() -> Generator[Mock, None, None]:
     with patch("personal_finances.bank_interface.client.NordigenClient") as mock:
         mock.return_value.generate_token.__name__ = "generate_token"
-
         mock.return_value.institution.get_institution_id_by_name.__name__ = (
             "get_institution_id_by_name"
         )
@@ -37,10 +48,8 @@ def nordigen_client_mock() -> Generator[Mock, None, None]:
             "get_requisition_by_id"
         )
         mock.return_value.requisition.get_requisition_by_id.side_effect = [
-            {"accounts": ["account1"]},
-            {"accounts": ["account2"]},
-            {"accounts": ["account3"]},
-            {"accounts": ["account4"]},
+            {"accounts": ["account11", "account12"]},
+            {"accounts": ["account21", "account22"]},
         ]
 
         mock.return_value.account_api.__name__ = "account_api"
@@ -74,6 +83,32 @@ def nordigen_client_mock() -> Generator[Mock, None, None]:
             },
         ]
 
+        yield mock
+
+
+@fixture(autouse=True)
+def disk_token_store_mock() -> Generator[Mock, None, None]:
+    with patch("personal_finances.bank_interface.client.DiskTokenStore") as mock:
+        mock.return_value.get_last_token.return_value = TokenObject(
+            AccessToken="fake-last-access-token",
+            AccessExpires=10,
+            AccessRefreshEpoch=123122,
+            RefreshToken="fake-last-refresh-token",
+            RefreshExpires=50,
+            CreationEpoch=123123,
+        )
+        yield mock
+
+
+@fixture(autouse=True)
+def disk_requisition_store_mock() -> Generator[Mock, None, None]:
+    with patch("personal_finances.bank_interface.client.DiskRequisitionStore") as mock:
+        mock.return_value.get_last_requisitions.return_value = Requisitions(
+            RequisitionIds=[
+                "requisition-from-disk",
+                "requisition-persisted-from-store",
+            ]
+        )
         yield mock
 
 
@@ -116,7 +151,10 @@ def time_mock() -> Generator[Mock, None, None]:
         yield mock
 
 
-def test_bank_client_initializes(nordigen_client_mock: Mock) -> None:
+def test_bank_client_initializes_valid_access_token(
+    nordigen_client_mock: Mock, disk_token_store_mock: Mock
+) -> None:
+    disk_token_store_mock.return_value.is_access_token_valid.return_value = True
     BankClient(
         NordigenAuth(secret_id="mock_secret_id", secret_key="mock_secret_key"),
         [
@@ -124,9 +162,91 @@ def test_bank_client_initializes(nordigen_client_mock: Mock) -> None:
             BankDetails(name="mock_name2", country="mock_country2"),
         ],
     )
+    disk_token_store_mock.return_value.get_last_token.assert_called_once_with(
+        "temporary-user-id"
+    )
     nordigen_client_mock.assert_called_with(
         secret_id="mock_secret_id", secret_key="mock_secret_key"
     )
+    assert nordigen_client_mock.return_value.token == "fake-last-access-token"
+
+
+def test_bank_client_initializes_valid_refresh_token(
+    nordigen_client_mock: Mock, disk_token_store_mock: Mock
+) -> None:
+    disk_token_store_mock.return_value.is_access_token_valid.return_value = False
+    disk_token_store_mock.return_value.is_refresh_token_valid.return_value = True
+    nordigen_client_mock.return_value.exchange_token.return_value = {
+        "access": "newly-generated-token",
+        "access_expires": 10,
+    }
+    BankClient(
+        NordigenAuth(secret_id="mock_secret_id", secret_key="mock_secret_key"),
+        [
+            BankDetails(name="mock_name1", country="mock_country1"),
+            BankDetails(name="mock_name2", country="mock_country2"),
+        ],
+    )
+    disk_token_store_mock.return_value.get_last_token.assert_called_once_with(
+        "temporary-user-id"
+    )
+    disk_token_store_mock.return_value.save_token.assert_called_once_with(
+        "temporary-user-id",
+        TokenObject(
+            AccessToken="newly-generated-token",
+            AccessExpires=10,
+            AccessRefreshEpoch=321,
+            RefreshToken="fake-last-refresh-token",
+            RefreshExpires=50,
+            CreationEpoch=123123,
+        ),
+    )
+    nordigen_client_mock.assert_called_with(
+        secret_id="mock_secret_id", secret_key="mock_secret_key"
+    )
+    nordigen_client_mock.return_value.exchange_token.assert_called_once_with(
+        "fake-last-refresh-token"
+    )
+
+
+def test_bank_client_initializes_invalid_token(
+    nordigen_client_mock: Mock, disk_token_store_mock: Mock
+) -> None:
+    disk_token_store_mock.return_value.is_access_token_valid.return_value = False
+    disk_token_store_mock.return_value.is_refresh_token_valid.return_value = False
+
+    nordigen_client_mock.return_value.generate_token.return_value = {
+        "access": "newly-generated-token",
+        "access_expires": 10,
+        "refresh": "newly-generated-token",
+        "refresh_expires": 50,
+    }
+
+    BankClient(
+        NordigenAuth(secret_id="mock_secret_id", secret_key="mock_secret_key"),
+        [
+            BankDetails(name="mock_name1", country="mock_country1"),
+            BankDetails(name="mock_name2", country="mock_country2"),
+        ],
+    )
+
+    disk_token_store_mock.return_value.get_last_token.assert_not_called()
+    disk_token_store_mock.return_value.save_token.assert_called_once_with(
+        "temporary-user-id",
+        TokenObject(
+            AccessToken="newly-generated-token",
+            AccessExpires=10,
+            AccessRefreshEpoch=321,
+            RefreshToken="newly-generated-token",
+            RefreshExpires=50,
+            CreationEpoch=321,
+        ),
+    )
+    nordigen_client_mock.assert_called_with(
+        secret_id="mock_secret_id", secret_key="mock_secret_key"
+    )
+    nordigen_client_mock.return_value.generate_token.assert_called_once_with()
+    assert nordigen_client_mock.return_value.token == "newly-generated-token"
 
 
 def test_bank_client_scope(subprocess_mock: Mock, os_mock: Mock) -> None:
@@ -147,9 +267,15 @@ def test_bank_client_scope(subprocess_mock: Mock, os_mock: Mock) -> None:
     os_mock.killpg.assert_called_with(os_mock.getpgid.return_value, signal.SIGTERM)
 
 
-def test_bank_client_calls_nordigen_client(
-    nordigen_client_mock: Mock, requests_mock: Mock, webbrowser_mock: Mock
+def test_bank_client_empty_requisition_store(
+    nordigen_client_mock: Mock,
+    disk_requisition_store_mock: Mock,
+    requests_mock: Mock,
+    webbrowser_mock: Mock,
 ) -> None:
+    disk_requisition_store_mock.return_value.are_all_requisition_valid.return_value = (
+        False
+    )
     nordigen_client = nordigen_client_mock.return_value
     with BankClient(
         NordigenAuth(secret_id="mock_secret_id", secret_key="mock_secret_key"),
@@ -160,11 +286,23 @@ def test_bank_client_calls_nordigen_client(
     ) as client:
         response = client.get_transactions()
 
-    assert response == {
-        "booked": ["transaction_b11", "transaction_b12", "transaction_b21"],
-        "pending": ["transaction_p11", "transaction_p21", "transaction_p22"],
+    assert cast(Dict, response) == {
+        "booked": [
+            "transaction_b11",
+            "transaction_b12",
+            "transaction_b21",
+            "transaction_b31",
+            "transaction_b41",
+            "transaction_b42",
+        ],
+        "pending": [
+            "transaction_p11",
+            "transaction_p21",
+            "transaction_p22",
+            "transaction_p31",
+            "transaction_p41",
+        ],
     }
-    nordigen_client.generate_token.assert_called_once()
     nordigen_client.initialize_session.assert_has_calls(
         [
             call(
@@ -178,6 +316,22 @@ def test_bank_client_calls_nordigen_client(
                 reference_id="Diego Personal PC 2",
             ),
         ]
+    )
+    assert (
+        disk_requisition_store_mock.return_value.are_all_requisition_valid.call_args[0][
+            0
+        ]
+        == "temporary-user-id"
+    )
+    assert isinstance(
+        disk_requisition_store_mock.return_value.are_all_requisition_valid.call_args[0][
+            1
+        ],
+        GocardlessRequisitionValidator,
+    )
+    disk_requisition_store_mock.return_value.save_requisitions.assert_called_once_with(
+        "temporary-user-id",
+        Requisitions(RequisitionIds=["requisition_id1", "requisition_id2"]),
     )
     nordigen_client.institution.get_institution_id_by_name.assert_has_calls(
         [
@@ -200,4 +354,72 @@ def test_bank_client_calls_nordigen_client(
     assert nordigen_client.initialize_session.call_count == 2
     assert nordigen_client.institution.get_institution_id_by_name.call_count == 2
     assert nordigen_client.requisition.get_requisition_by_id.call_count == 2
-    assert nordigen_client.account_api.return_value.get_transactions.call_count == 2
+    assert nordigen_client.account_api.return_value.get_transactions.call_count == 4
+
+
+def test_bank_client_existing_requisition_store(
+    nordigen_client_mock: Mock,
+    disk_requisition_store_mock: Mock,
+    requests_mock: Mock,
+    webbrowser_mock: Mock,
+) -> None:
+    disk_requisition_store_mock.return_value.are_all_requisition_valid.return_value = (
+        True
+    )
+
+    nordigen_client = nordigen_client_mock.return_value
+    with BankClient(
+        NordigenAuth(secret_id="mock_secret_id", secret_key="mock_secret_key"),
+        [
+            BankDetails(name="mock_name1", country="mock_country1"),
+            BankDetails(name="mock_name2", country="mock_country2"),
+        ],
+    ) as client:
+        response = client.get_transactions()
+
+    assert cast(Dict, response) == {
+        "booked": [
+            "transaction_b11",
+            "transaction_b12",
+            "transaction_b21",
+            "transaction_b31",
+            "transaction_b41",
+            "transaction_b42",
+        ],
+        "pending": [
+            "transaction_p11",
+            "transaction_p21",
+            "transaction_p22",
+            "transaction_p31",
+            "transaction_p41",
+        ],
+    }
+    nordigen_client.initialize_session.assert_not_called()
+    assert (
+        disk_requisition_store_mock.return_value.are_all_requisition_valid.call_args[0][
+            0
+        ]
+        == "temporary-user-id"
+    )
+    assert isinstance(
+        disk_requisition_store_mock.return_value.are_all_requisition_valid.call_args[0][
+            1
+        ],
+        GocardlessRequisitionValidator,
+    )
+
+    disk_requisition_store_mock.return_value.save_requisitions.assert_not_called()
+    nordigen_client.institution.get_institution_id_by_name.assert_not_called()
+    nordigen_client.requisition.get_requisition_by_id.assert_has_calls(
+        [
+            call(requisition_id="requisition-from-disk"),
+            call(requisition_id="requisition-persisted-from-store"),
+        ]
+    )
+    nordigen_client.account_api.return_value.get_transactions.assert_has_calls(
+        [call(), call()]
+    )
+    requests_mock.get.assert_not_called()
+    webbrowser_mock.open.assert_not_called()
+    assert nordigen_client.requisition.get_requisition_by_id.call_count == 2
+    assert nordigen_client.account_api.return_value.get_transactions.call_count == 4

--- a/tests/bank_interface/test_disk_requisition_store.py
+++ b/tests/bank_interface/test_disk_requisition_store.py
@@ -1,0 +1,129 @@
+from unittest.mock import patch, Mock
+from pydantic import ValidationError
+from pytest import raises, fixture
+from personal_finances.bank_interface.disk_requisition_store import (
+    DiskRequisitionStore,
+    RequisitionAbsolutePathNotConfigured,
+)
+from personal_finances.bank_interface.key_value_disk_store import ValueNotFound
+from personal_finances.bank_interface.requisition_store import (
+    EMPTY_REQUISITIONS,
+    Requisitions,
+)
+from typing import Generator
+
+
+class SomeBizarreError(Exception):
+    pass
+
+
+@fixture(autouse=True)
+def key_value_disk_mock() -> Generator[Mock, None, None]:
+    with patch(
+        "personal_finances.bank_interface.disk_requisition_store.KeyValueDiskStore",
+    ) as m:
+        yield m
+
+
+@fixture(autouse=True)
+def env_mock() -> Generator[Mock, None, None]:
+    with patch(
+        "personal_finances.bank_interface.disk_requisition_store.os.environ"
+    ) as m:
+        m.__getitem__.side_effect = {
+            "REQUISITION_DISK_PATH_PREFIX": "/test-requisition/path"
+        }.__getitem__
+        yield m
+
+
+@fixture(autouse=True)
+def mock_file_os() -> Generator[Mock, None, None]:
+    with patch("personal_finances.file_helper.os") as env_mock:
+        yield env_mock
+
+
+def test_rejects_missing_requisition_path(env_mock: Mock) -> None:
+    env_mock.__getitem__.side_effect = KeyError
+    with raises(RequisitionAbsolutePathNotConfigured):
+        disk_store = DiskRequisitionStore()
+        disk_store.get_last_requisitions("my-user-id")
+
+
+def test_save_requisitions_returns_previous_requisition(
+    key_value_disk_mock: Mock,
+) -> None:
+    new_requisition = Requisitions(RequisitionIds=["req1", "req2"])
+    previous_requisition = Requisitions(RequisitionIds=["req3", "req4"])
+
+    key_value_disk_mock.return_value.write_to_disk.return_value = (
+        previous_requisition.model_dump_json()
+    )
+
+    disk_store = DiskRequisitionStore()
+    disk_store.save_requisitions("my-user-id", new_requisition)
+    key_value_disk_mock.return_value.write_to_disk.assert_called_once_with(
+        "my-user-id.json", new_requisition.model_dump_json()
+    )
+
+    disk_store = DiskRequisitionStore()
+    retrieved_previous_requisition = disk_store.save_requisitions(
+        "my-user-id", new_requisition
+    )
+    assert retrieved_previous_requisition == previous_requisition
+
+
+def test_save_requisitions_returns_none_json_error(key_value_disk_mock: Mock) -> None:
+    new_requisition = Requisitions(RequisitionIds=["req1", "req2"])
+
+    key_value_disk_mock.return_value.write_to_disk.return_value = "{malformed-json["
+
+    disk_store = DiskRequisitionStore()
+    retrieved_previous_requisition = disk_store.save_requisitions(
+        "my-user-id", new_requisition
+    )
+    assert retrieved_previous_requisition == EMPTY_REQUISITIONS
+
+
+def test_save_requisitions_reraises_write_error(key_value_disk_mock: Mock) -> None:
+    new_requisition = Requisitions(RequisitionIds=["req1", "req2"])
+
+    key_value_disk_mock.return_value.write_to_disk.side_effect = SomeBizarreError
+
+    disk_store = DiskRequisitionStore()
+
+    with raises(SomeBizarreError):
+        disk_store.save_requisitions("my-user-id", new_requisition)
+
+
+def test_get_last_requisitions_not_found_error(key_value_disk_mock: Mock) -> None:
+    key_value_disk_mock.return_value.read_from_disk.side_effect = ValueNotFound
+    disk_store = DiskRequisitionStore()
+
+    assert disk_store.get_last_requisitions("my-user-id") == EMPTY_REQUISITIONS
+
+
+def test_get_last_requisitions_reraises_file_error(key_value_disk_mock: Mock) -> None:
+    key_value_disk_mock.return_value.read_from_disk.side_effect = SomeBizarreError
+    disk_store = DiskRequisitionStore()
+
+    with raises(SomeBizarreError):
+        disk_store.get_last_requisitions("my-user-id")
+
+
+def test_get_last_requisitions_raises_json_error(key_value_disk_mock: Mock) -> None:
+    disk_store = DiskRequisitionStore()
+
+    key_value_disk_mock.return_value.read_from_disk.return_value = "{malformed[json:"
+    with raises(ValidationError):
+        disk_store.get_last_requisitions("my-user-id")
+
+
+def test_get_last_requisitions_succeeds(key_value_disk_mock: Mock) -> None:
+    last_requisition = Requisitions(RequisitionIds=["req1", "req2"])
+    disk_store = DiskRequisitionStore()
+
+    key_value_disk_mock.return_value.read_from_disk.return_value = (
+        last_requisition.model_dump_json()
+    )
+    returned_last_requisition = disk_store.get_last_requisitions("my-user-id")
+    assert returned_last_requisition == last_requisition

--- a/tests/bank_interface/test_disk_token_store.py
+++ b/tests/bank_interface/test_disk_token_store.py
@@ -1,0 +1,154 @@
+from unittest.mock import patch, Mock
+from pydantic import ValidationError
+from pytest import raises, fixture
+from personal_finances.bank_interface.disk_token_store import (
+    DiskTokenStore,
+    TokenAbsolutePathNotConfigured,
+)
+from personal_finances.bank_interface.key_value_disk_store import ValueNotFound
+from personal_finances.bank_interface.token_store import TokenObject, TokenNotFound
+from typing import Generator
+
+
+class SomeBizarreError(Exception):
+    pass
+
+
+@fixture(autouse=True)
+def key_value_disk_mock() -> Generator[Mock, None, None]:
+    with patch(
+        "personal_finances.bank_interface.disk_token_store.KeyValueDiskStore",
+    ) as m:
+        yield m
+
+
+@fixture(autouse=True)
+def env_mock() -> Generator[Mock, None, None]:
+    with patch("personal_finances.bank_interface.disk_token_store.os.environ") as m:
+        m.__getitem__.side_effect = {
+            "TOKEN_DISK_PATH_PREFIX": "/test-token/path"
+        }.__getitem__
+        yield m
+
+
+@fixture(autouse=True)
+def mock_file_os() -> Generator[Mock, None, None]:
+    with patch("personal_finances.file_helper.os") as env_mock:
+        yield env_mock
+
+
+def test_rejects_missing_token_path(env_mock: Mock) -> None:
+    env_mock.__getitem__.side_effect = KeyError
+    with raises(TokenAbsolutePathNotConfigured):
+        disk_store = DiskTokenStore()
+        disk_store.get_last_token("my-user-id")
+
+
+def test_save_token_returns_previous_token(key_value_disk_mock: Mock) -> None:
+    new_token = TokenObject(
+        AccessToken="fake-access-token",
+        AccessExpires=10,
+        AccessRefreshEpoch=123122,
+        RefreshToken="fake-refresh-token",
+        RefreshExpires=50,
+        CreationEpoch=123123,
+    )
+    previous_token = TokenObject(
+        AccessToken="previous-fake-access-token",
+        AccessExpires=11,
+        AccessRefreshEpoch=123122,
+        RefreshToken="previous-fake-refresh-token",
+        RefreshExpires=51,
+        CreationEpoch=123124,
+    )
+
+    key_value_disk_mock.return_value.write_to_disk.return_value = (
+        previous_token.model_dump_json()
+    )
+
+    disk_store = DiskTokenStore()
+    disk_store.save_token("my-user-id", new_token)
+    key_value_disk_mock.return_value.write_to_disk.assert_called_once_with(
+        "my-user-id.json", new_token.model_dump_json()
+    )
+
+    disk_store = DiskTokenStore()
+    retrieved_previous_token = disk_store.save_token("my-user-id", new_token)
+    assert retrieved_previous_token == previous_token
+
+
+def test_save_token_returns_none_json_error(key_value_disk_mock: Mock) -> None:
+    new_token = TokenObject(
+        AccessToken="fake-access-token",
+        AccessExpires=10,
+        AccessRefreshEpoch=123122,
+        RefreshToken="fake-refresh-token",
+        RefreshExpires=50,
+        CreationEpoch=123123,
+    )
+
+    key_value_disk_mock.return_value.write_to_disk.return_value = "{malformed-json["
+
+    disk_store = DiskTokenStore()
+    retrieved_previous_token = disk_store.save_token("my-user-id", new_token)
+    assert retrieved_previous_token is None
+
+
+def test_save_token_reraises_write_error(key_value_disk_mock: Mock) -> None:
+    new_token = TokenObject(
+        AccessToken="fake-access-token",
+        AccessExpires=10,
+        AccessRefreshEpoch=123122,
+        RefreshToken="fake-refresh-token",
+        RefreshExpires=50,
+        CreationEpoch=123123,
+    )
+
+    key_value_disk_mock.return_value.write_to_disk.side_effect = SomeBizarreError
+
+    disk_store = DiskTokenStore()
+
+    with raises(SomeBizarreError):
+        disk_store.save_token("my-user-id", new_token)
+
+
+def test_get_last_token_not_found_error(key_value_disk_mock: Mock) -> None:
+    key_value_disk_mock.return_value.read_from_disk.side_effect = ValueNotFound
+    disk_store = DiskTokenStore()
+
+    with raises(TokenNotFound):
+        disk_store.get_last_token("my-user-id")
+
+
+def test_get_last_token_reraises_file_error(key_value_disk_mock: Mock) -> None:
+    key_value_disk_mock.return_value.read_from_disk.side_effect = SomeBizarreError
+    disk_store = DiskTokenStore()
+
+    with raises(SomeBizarreError):
+        disk_store.get_last_token("my-user-id")
+
+
+def test_get_last_token_raises_json_error(key_value_disk_mock: Mock) -> None:
+    disk_store = DiskTokenStore()
+
+    key_value_disk_mock.return_value.read_from_disk.return_value = "{malformed[json:"
+    with raises(ValidationError):
+        disk_store.get_last_token("my-user-id")
+
+
+def test_get_last_token_succeeds(key_value_disk_mock: Mock) -> None:
+    last_token = TokenObject(
+        AccessToken="fake-access-token",
+        AccessExpires=10,
+        AccessRefreshEpoch=123122,
+        RefreshToken="fake-refresh-token",
+        RefreshExpires=50,
+        CreationEpoch=123123,
+    )
+    disk_store = DiskTokenStore()
+
+    key_value_disk_mock.return_value.read_from_disk.return_value = (
+        last_token.model_dump_json()
+    )
+    returned_last_token = disk_store.get_last_token("my-user-id")
+    assert returned_last_token == last_token

--- a/tests/bank_interface/test_key_value_disk_store.py
+++ b/tests/bank_interface/test_key_value_disk_store.py
@@ -1,0 +1,67 @@
+from typing import Generator
+from unittest.mock import patch, Mock, mock_open
+
+from pytest import fixture, raises
+
+from personal_finances.bank_interface.key_value_disk_store import (
+    KeyValueDiskStore,
+    InvalidAbsolutePath,
+    ValueNotFound,
+)
+
+
+class TestKeyValueDiskStore:
+    @fixture
+    def mock_write_string(self) -> Generator[Mock, None, None]:
+        with patch(
+            "personal_finances.bank_interface.key_value_disk_store.write_string"
+        ) as m:
+            yield m
+
+    def test_init_with_non_absolute_path(self) -> None:
+        with raises(InvalidAbsolutePath):
+            KeyValueDiskStore("relative/path")
+
+    def test_init_with_empty_path_parts(self) -> None:
+        with raises(InvalidAbsolutePath):
+            KeyValueDiskStore("/valid//path/with/empty/part")
+
+    def test_init_valid(self) -> None:
+        store = KeyValueDiskStore("/valid/path")
+        assert store.path_prefix == "/valid/path"
+
+    def test_remove_trailing_char(self) -> None:
+        store = KeyValueDiskStore("/valid/path/")
+        assert store.path_prefix == "/valid/path"
+
+    def test_write_to_disk_with_forward_slash(self, mock_write_string: Mock) -> None:
+        """Test writing data to disk."""
+        store = KeyValueDiskStore("/valid/path/")
+        mock_write_string.return_value = "Success"
+        result = store.write_to_disk("file.txt", "write-data")
+        mock_write_string.assert_called_with("/valid/path/file.txt", "write-data")
+        assert result == "Success"
+
+    def test_write_to_disk_without_forward_slash(self, mock_write_string: Mock) -> None:
+        """Test writing data to disk."""
+        store = KeyValueDiskStore("/valid/path")
+        mock_write_string.return_value = "Success"
+        result = store.write_to_disk("file.txt", "write-data")
+        mock_write_string.assert_called_with("/valid/path/file.txt", "write-data")
+        assert result == "Success"
+
+    @patch("builtins.open", new_callable=mock_open, read_data="read-data")
+    def test_read_from_disk(self, mock_open: Mock) -> None:
+        """Test reading data from disk."""
+        store = KeyValueDiskStore("/valid/path")
+        result = store.read_from_disk("file.txt")
+        mock_open.assert_called_with("/valid/path/file.txt", "r")
+        assert result == "read-data"
+
+    @patch("builtins.open", new_callable=mock_open)
+    def test_read_from_disk_fail(self, mock_open: Mock) -> None:
+        """Test exception handling when reading from disk fails."""
+        mock_open.side_effect = Exception("File not found")
+        store = KeyValueDiskStore("/valid/path")
+        with raises(ValueNotFound):
+            store.read_from_disk("nonexistent.txt")

--- a/tests/bank_interface/test_nordigen_adapter.py
+++ b/tests/bank_interface/test_nordigen_adapter.py
@@ -1,0 +1,43 @@
+from typing import cast
+from personal_finances.bank_interface.nordigen_adapter import (
+    EMPTY_NORDIGEN_TRANSACTIONS,
+    NordigenTransactions,
+    concat_nordigen_transactions,
+)
+
+
+def test_concat_nordigen_transactions_double_empty() -> None:
+    assert (
+        concat_nordigen_transactions(
+            EMPTY_NORDIGEN_TRANSACTIONS, EMPTY_NORDIGEN_TRANSACTIONS
+        )
+        == EMPTY_NORDIGEN_TRANSACTIONS
+    )
+
+
+def test_concat_nordigen_transactions_left_empty() -> None:
+    simple_transactions = {"booked": ["fake-tr1"], "pending": ["fake-tr2"]}
+    assert concat_nordigen_transactions(
+        EMPTY_NORDIGEN_TRANSACTIONS, cast(NordigenTransactions, simple_transactions)
+    ) == cast(NordigenTransactions, simple_transactions)
+
+
+def test_concat_nordigen_transactions_right_empty() -> None:
+    simple_transactions = {"booked": ["fake-tr1"], "pending": ["fake-tr2"]}
+    assert concat_nordigen_transactions(
+        cast(NordigenTransactions, simple_transactions),
+        EMPTY_NORDIGEN_TRANSACTIONS,
+    ) == cast(NordigenTransactions, simple_transactions)
+
+
+def test_concat_nordigen_transactions() -> None:
+    simple_transactions = {"booked": ["tr1"], "pending": ["tr2"]}
+    another_transactions = {"booked": ["tr3"], "pending": ["tr4"]}
+    expected_nordigen_transactions = {
+        "booked": ["tr3", "tr1"],
+        "pending": ["tr4", "tr2"],
+    }
+    assert concat_nordigen_transactions(
+        cast(NordigenTransactions, another_transactions),
+        cast(NordigenTransactions, simple_transactions),
+    ) == cast(NordigenTransactions, expected_nordigen_transactions)

--- a/tests/bank_interface/test_requisition_store.py
+++ b/tests/bank_interface/test_requisition_store.py
@@ -1,0 +1,74 @@
+from unittest.mock import Mock
+from personal_finances.bank_interface.requisition_store import (
+    gocardless_requisition_adapter,
+    GocardlessRequisitionValidator,
+    Requisitions,
+    RequisitionStore,
+    EMPTY_REQUISITIONS,
+)
+from nordigen.types import RequisitionDto
+from typing import cast
+
+
+class MockRequisitionStore(RequisitionStore):
+    def __init__(self, test_mock: Mock):
+        self.test_mock = test_mock
+
+    def save_requisitions(
+        self, user_id: str, requisition: Requisitions
+    ) -> Requisitions:
+        return cast(Requisitions, self.test_mock.save_requisition(user_id, requisition))
+
+    def get_last_requisitions(self, user_id: str) -> Requisitions:
+        return cast(Requisitions, self.test_mock.get_last_requisition(user_id))
+
+
+def test_requisition_adapter_empty_requisitions() -> None:
+    assert gocardless_requisition_adapter([]) == EMPTY_REQUISITIONS
+
+
+def test_requisition_adapter() -> None:
+    assert gocardless_requisition_adapter(
+        [
+            RequisitionDto(requisition_id="1", link="l1"),
+            RequisitionDto(requisition_id="2", link="l2"),
+        ]
+    ) == Requisitions(RequisitionIds=["1", "2"])
+
+
+def test_requisition_store_valid_access_requisition() -> None:
+    last_requisition = Requisitions(RequisitionIds=["1", "2"])
+
+    requisition_store_mock = Mock()
+    requisition_store_mock.get_last_requisition.return_value = last_requisition
+    test_store = MockRequisitionStore(requisition_store_mock)
+    gocardless_api_mock = Mock()
+    gocardless_api_mock.get_requisition_by_id.return_value = {"status": "LN"}
+    validator = GocardlessRequisitionValidator(gocardless_api_mock)
+    assert test_store.are_all_requisition_valid("my-user-id", validator) is True
+    requisition_store_mock.get_last_requisition.assert_called_once_with("my-user-id")
+
+
+def test_requisition_store_one_invalid() -> None:
+    last_requisition = Requisitions(RequisitionIds=["1", "2"])
+
+    requisition_store_mock = Mock()
+    requisition_store_mock.get_last_requisition.return_value = last_requisition
+    test_store = MockRequisitionStore(requisition_store_mock)
+    gocardless_api_mock = Mock()
+    gocardless_api_mock.get_requisition_by_id.side_effect = [
+        {"status": "LN"},  # <-- valid one
+        {"status": "INVALID"},
+    ]
+    validator = GocardlessRequisitionValidator(gocardless_api_mock)
+    assert test_store.are_all_requisition_valid("my-user-id", validator) is False
+    requisition_store_mock.get_last_requisition.assert_called_once_with("my-user-id")
+
+
+def test_requisition_store_empty_is_invalid() -> None:
+    requisition_store_mock = Mock()
+    requisition_store_mock.get_last_requisition.return_value = EMPTY_REQUISITIONS
+    test_store = MockRequisitionStore(requisition_store_mock)
+    validator = GocardlessRequisitionValidator(Mock())
+    assert test_store.are_all_requisition_valid("my-user-id", validator) is False
+    requisition_store_mock.get_last_requisition.assert_called_once_with("my-user-id")

--- a/tests/bank_interface/test_token_store.py
+++ b/tests/bank_interface/test_token_store.py
@@ -1,0 +1,181 @@
+from unittest.mock import patch, Mock
+from pytest import fixture, raises
+from typing import Generator, Optional, cast
+from pydantic import ValidationError
+import personal_finances.bank_interface.token_store as ts
+
+
+class MockTokenStore(ts.TokenStore):
+    def __init__(self, test_mock: Mock):
+        self.test_mock = test_mock
+
+    def save_token(
+        self, user_id: str, token: ts.TokenObject
+    ) -> Optional[ts.TokenObject]:
+        return cast(Optional[ts.TokenObject], self.test_mock.save_token(user_id, token))
+
+    def get_last_token(self, user_id: str) -> ts.TokenObject:
+        return cast(ts.TokenObject, self.test_mock.get_last_token(user_id))
+
+
+@fixture(autouse=True)
+def datetime_mock() -> Generator[Mock, None, None]:
+    with patch("personal_finances.bank_interface.token_store.datetime") as mock:
+        mock.now.return_value.timestamp.return_value = 123123
+        yield mock
+
+
+def test_token_adapter_raises_missing_keys() -> None:
+    with raises(KeyError):
+        ts.gocardless_token_adapter(
+            {
+                "access": "fake-access",
+                "access_expires": 10,
+                "refresh": "fake-refresh",
+                # Missing refresh_expires
+                # "refresh_expires": 10,
+            }
+        )
+
+
+def test_token_adapter_raises_wrong_type() -> None:
+    with raises(ValidationError):
+        ts.gocardless_token_adapter(
+            {
+                "access": "fake-access",
+                "access_expires": 10,
+                "refresh": "fake-refresh",
+                "refresh_expires": "wrong-type-here",
+            }
+        )
+
+
+def test_token_adapter_ignores_extra_keys() -> None:
+    token_object = ts.gocardless_token_adapter(
+        {
+            "access": "fake-access",
+            "access_expires": 10,
+            "refresh": "fake-refresh",
+            "refresh_expires": 50,
+            "should-ignore-this-key": "also-this vlaue",
+        }
+    )
+    assert token_object.AccessToken == "fake-access"
+    assert token_object.AccessExpires == 10
+    assert token_object.RefreshToken == "fake-refresh"
+    assert token_object.RefreshExpires == 50
+    assert token_object.CreationEpoch == 123123
+
+
+def test_token_store_valid_access_token() -> None:
+    last_token = ts.TokenObject(
+        AccessToken="fake-access-token",
+        AccessExpires=10,
+        AccessRefreshEpoch=123122,
+        RefreshToken="fake-refresh-token",
+        RefreshExpires=50,
+        # making AccessExpires + CreationEpoch bigger than mocked now (123123)
+        CreationEpoch=123123 - 10 + 1,
+    )
+
+    token_store_mock = Mock()
+    token_store_mock.get_last_token.return_value = last_token
+    test_store = MockTokenStore(token_store_mock)
+    assert test_store.is_access_token_valid("my-user-id") is True
+    token_store_mock.get_last_token.assert_called_once_with("my-user-id")
+
+
+def test_token_store_expired_access_token() -> None:
+    last_token = ts.TokenObject(
+        AccessToken="fake-access-token",
+        AccessExpires=10,
+        # making AccessExpires + AccessRefreshEpoch equal than mocked now (123123)
+        AccessRefreshEpoch=123122 - 10,
+        RefreshToken="fake-refresh-token",
+        RefreshExpires=50,
+        CreationEpoch=123123,
+    )
+
+    token_store_mock = Mock()
+    token_store_mock.get_last_token.return_value = last_token
+    test_store = MockTokenStore(token_store_mock)
+    assert test_store.is_access_token_valid("my-user-id") is False
+    token_store_mock.get_last_token.assert_called_once_with("my-user-id")
+
+
+def test_token_store_not_found_access_token() -> None:
+    token_store_mock = Mock()
+    token_store_mock.get_last_token.side_effect = ts.TokenNotFound
+    test_store = MockTokenStore(token_store_mock)
+    assert test_store.is_access_token_valid("my-user-id") is False
+    token_store_mock.get_last_token.assert_called_once_with("my-user-id")
+
+
+def test_token_store_valid_refresh_token() -> None:
+    last_token = ts.TokenObject(
+        AccessToken="fake-access-token",
+        AccessExpires=10,
+        AccessRefreshEpoch=123122,
+        RefreshToken="fake-refresh-token",
+        RefreshExpires=50,
+        # making RefreshExpires + CreationEpoch bigger than mocked now (123123)
+        CreationEpoch=123123 - 50 + 1,
+    )
+
+    token_store_mock = Mock()
+    token_store_mock.get_last_token.return_value = last_token
+    test_store = MockTokenStore(token_store_mock)
+    assert test_store.is_refresh_token_valid("my-user-id") is True
+    token_store_mock.get_last_token.assert_called_once_with("my-user-id")
+
+
+def test_token_store_invalid_refresh_token() -> None:
+    last_token = ts.TokenObject(
+        AccessToken="fake-access-token",
+        AccessExpires=10,
+        AccessRefreshEpoch=123122,
+        RefreshToken="fake-refresh-token",
+        RefreshExpires=50,
+        # making RefreshExpires + CreationEpoch bigger than mocked now (123123)
+        CreationEpoch=123123 - 50,
+    )
+
+    token_store_mock = Mock()
+    token_store_mock.get_last_token.return_value = last_token
+    test_store = MockTokenStore(token_store_mock)
+    assert test_store.is_refresh_token_valid("my-user-id") is False
+    token_store_mock.get_last_token.assert_called_once_with("my-user-id")
+
+
+def test_token_store_not_found_refresh_token() -> None:
+    token_store_mock = Mock()
+    token_store_mock.get_last_token.side_effect = ts.TokenNotFound
+    test_store = MockTokenStore(token_store_mock)
+    assert test_store.is_refresh_token_valid("my-user-id") is False
+    token_store_mock.get_last_token.assert_called_once_with("my-user-id")
+
+
+def test_token_store_child_save_token() -> None:
+    previous_token = ts.TokenObject(
+        AccessToken="previous-fake-access-token",
+        AccessExpires=11,
+        AccessRefreshEpoch=123122,
+        RefreshToken="previous-fake-refresh-token",
+        RefreshExpires=51,
+        CreationEpoch=123124,
+    )
+    token_to_be_saved = ts.TokenObject(
+        AccessToken="fake-access-token",
+        AccessExpires=10,
+        AccessRefreshEpoch=123122,
+        RefreshToken="fake-refresh-token",
+        RefreshExpires=50,
+        CreationEpoch=123123,
+    )
+
+    token_store_mock = Mock()
+    token_store_mock.save_token.return_value = previous_token
+    test_store = MockTokenStore(token_store_mock)
+    retured_token = test_store.save_token("my-user-id", token_to_be_saved)
+    assert retured_token == previous_token
+    token_store_mock.save_token.assert_called_once_with("my-user-id", token_to_be_saved)

--- a/tests/test_file_helper.py
+++ b/tests/test_file_helper.py
@@ -1,0 +1,55 @@
+from unittest.mock import mock_open, patch, Mock, call
+from pytest import fixture, raises
+from typing import Generator
+from personal_finances.file_helper import write_string
+
+
+@fixture(autouse=True)
+def os_mock() -> Generator[Mock, None, None]:
+    with patch("personal_finances.file_helper.os") as mock:
+        yield mock
+
+
+class MockException(Exception):
+    pass
+
+
+@patch("personal_finances.file_helper.open", new_callable=mock_open)
+def test_write_string_reraises_open_exception(open_mock: Mock) -> None:
+    open_mock.side_effect = MockException
+    with raises(MockException):
+        write_string("/my/path/file.txt", "test-content")
+
+
+@patch(
+    "personal_finances.file_helper.open",
+    new_callable=lambda: mock_open(read_data="previous content"),
+)
+def test_write_string_returns_previous_content(open_mock: Mock) -> None:
+    prev_content = write_string("/my/path/file.txt", "test-content")
+    assert prev_content == "previous content"
+    assert open_mock.mock_calls[0] == call("/my/path/file.txt", "w+")
+
+
+@patch("personal_finances.file_helper.open", new_callable=mock_open)
+def test_write_string_writes_to_file(open_mock: Mock) -> None:
+    write_string("/my/path/file.txt", "test-content")
+    file_handle = open_mock()
+    file_handle.write.assert_called_once_with("test-content")
+    assert open_mock.mock_calls[0] == call("/my/path/file.txt", "w+")
+
+
+@patch("personal_finances.file_helper.open", new_callable=mock_open)
+def test_write_string_writes_creates_path_dirs(open_mock: Mock, os_mock: Mock) -> None:
+    write_string("/my/path/file.txt", "test-content")
+    os_mock.makedirs.assert_called_once_with("/my/path")
+    assert open_mock.mock_calls[0] == call("/my/path/file.txt", "w+")
+
+
+@patch("personal_finances.file_helper.open", new_callable=mock_open)
+def test_write_string_override_existing_file(open_mock: Mock, os_mock: Mock) -> None:
+    os_mock.makedirs.side_effect = FileExistsError
+    write_string("/my/path/file.txt", "test-content")
+    file_handle = open_mock()
+    file_handle.write.assert_called_once_with("test-content")
+    assert open_mock.mock_calls[0] == call("/my/path/file.txt", "w+")


### PR DESCRIPTION
### ~DO NOT MERGE THIS BEFORE #27~ (already merged)

Current gocardless client credential logic is always generating new tokens in every access, requiring users to authenticate with their bank every time they need to fetch transactions from banks.

This PR introduces a new logic exploring two elements of the the GoCardless token API:
1. Reusing gocardless api tokens for as long as they are valid. By default, access tokens are valid for 24 hours and refresh tokens are valid for 90 days. The solution here involves persisting the generated tokens in a `TokenStore` for future re-use of tokens.
2. Reusing `Requisition` ids coming from Gocardless API by persisting them. This is what allows the software to reuse user's previously authenticated requisitions.

Three important observations:
1. I'm introducing the concept of users in this functionality, even though we don't have that concept yet, to leave the door open for a multi-user feature coming at some point soon.
3. At the moment there is no cloud deployment of this application, so I have implemented a persistence stores that uses local disk. I left the door open for future possible stores in the abstract classes `TokenStore` and `RequisitionStore`.
4. I didn't include encryption yet. I intend to do so before merging it, but feel free to review the current state and provide feedback.