### PR TITLE
Package creation for AWS Lambda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ reports/
 coverage.xml
 .env
 .vscode/
+package/*

--- a/Pipfile
+++ b/Pipfile
@@ -32,7 +32,7 @@ format = "black ."
 generate_reports = "python -m personal_finances.generate_reports"
 fetch_transactions = "python -m personal_finances.fetch_transactions"
 merge_transactions = "python -m personal_finances.merge_transactions"
-pack="""
+aws_pack="""
     bash -c ' \
     # Generate requirements.txt from Pipenv
     pipenv requirements > requirements.txt && \
@@ -40,7 +40,7 @@ pack="""
     # Create package directory and install dependencies using aws python image
     rm -rf package && \
     mkdir package && \
-    sudo docker run --rm -v $(pwd):/var/task --entrypoint /bin/bash public.ecr.aws/lambda/python:3.11 -c "\
+    docker run --rm -v $(pwd):/var/task --entrypoint /bin/bash public.ecr.aws/lambda/python:3.11 -c "\
     pip install boto3 -t ./package && \
     pip install -r requirements.txt -t ./package"
 

--- a/Pipfile
+++ b/Pipfile
@@ -38,13 +38,11 @@ pack="""
     pipenv requirements > requirements.txt && \
 
     # Create package directory and install dependencies using aws python image
-    mkdir -p package && \
+    rm -rf package && \
+    mkdir package && \
     sudo docker run --rm -v $(pwd):/var/task --entrypoint /bin/bash public.ecr.aws/lambda/python:3.11 -c "\
     pip install boto3 -t ./package && \
     pip install -r requirements.txt -t ./package"
-
-    # Remove old ZIP file if it exists
-    rm -f in_fin_core_package.zip && \
 
     # Zip the contents of the package directory
     (cd package && zip -r ../in_fin_core_package.zip ./*) && \

--- a/Pipfile
+++ b/Pipfile
@@ -32,3 +32,28 @@ format = "black ."
 generate_reports = "python -m personal_finances.generate_reports"
 fetch_transactions = "python -m personal_finances.fetch_transactions"
 merge_transactions = "python -m personal_finances.merge_transactions"
+pack="""
+    bash -c ' \
+    # Generate requirements.txt from Pipenv
+    pipenv requirements > requirements.txt && \
+
+    # Create package directory and install dependencies using aws python image
+    mkdir -p package && \
+    sudo docker run --rm -v $(pwd):/var/task --entrypoint /bin/bash public.ecr.aws/lambda/python:3.11 -c "\
+    pip install boto3 -t ./package && \
+    pip install -r requirements.txt -t ./package"
+
+    # Remove old ZIP file if it exists
+    rm -f in_fin_core_package.zip && \
+
+    # Zip the contents of the package directory
+    (cd package && zip -r ../in_fin_core_package.zip ./*) && \
+
+    # Add the personal_finances directory to the existing ZIP
+    zip -r in_fin_core_package.zip personal_finances && \
+    
+    # Cleaning 
+    rm requirements.txt && \
+    mv in_fin_core_package.zip ./package/in_fin_core_package.zip'
+"""
+

--- a/Pipfile
+++ b/Pipfile
@@ -32,7 +32,7 @@ format = "black ."
 generate_reports = "python -m personal_finances.generate_reports"
 fetch_transactions = "python -m personal_finances.fetch_transactions"
 merge_transactions = "python -m personal_finances.merge_transactions"
-aws_pack="""
+aws_lambda_pack="""
     bash -c ' \
     # Generate requirements.txt from Pipenv
     pipenv requirements > requirements.txt && \
@@ -40,9 +40,13 @@ aws_pack="""
     # Create package directory and install dependencies using aws python image
     rm -rf package && \
     mkdir package && \
-    docker run --rm -v $(pwd):/var/task --entrypoint /bin/bash public.ecr.aws/lambda/python:3.11 -c "\
-    pip install boto3 -t ./package && \
-    pip install -r requirements.txt -t ./package"
+    pip install \
+    --platform manylinux2014_x86_64 \
+    --target=package \
+    --implementation cp \
+    --python-version 3.11 \
+    --only-binary=:all: --upgrade \
+    --requirement requirements.txt && \
 
     # Zip the contents of the package directory
     (cd package && zip -r ../in_fin_core_package.zip ./*) && \

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ An alternative option is to set it in a `.env` file, [pipenv loads .env into env
 1. `pipenv run build`
 1. `pipenv run tests`
 1. `pipenv run format`
+1. `pipenv run aws_pack`
 1. `gh pr create --title "brand new feature"`
 
 ### Writing Tests
@@ -54,3 +55,51 @@ This repository implments tests using [pytest](https://docs.pytest.org/), the te
 
 [^env_vars]: [For linux](https://www.gnu.org/software/bash/manual/bash.html#Environment) you can either prepend as in `NAME=value pipenv ...` or use `export NAME=value`, [for windows](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/set_1) you can use `set`.
 [^user_config]: A more detailed documentation on [the user configuration file can be found here](docs/user_configuration_file.md).
+
+## AWS Packing
+Since some services from infin-neat-core code runs at AWS cloud services, it's necessary to properly pack the code to upload it using the web interface, AWS CLI, or AWS CDK. 
+
+For that, on specific script has been created and can be run using pipenv: 
+```
+pipenv run aws_pack
+```
+### Requirements:
+
+#### **Install Docker**: 
+Since in the packing processing Docker is used, it's necessary to install it. For installing Docker, the official documentation from Docker can be followed for [Linux](https://docs.docker.com/desktop/install/linux-install/), [Windows](https://docs.docker.com/desktop/install/windows-install/), and [MAC](https://docs.docker.com/desktop/install/mac-install/), 
+
+
+#### **Running Docker Rootless**: 
+
+Since the script uses **Docker** without root privileges, some extra steps are necessary to run the Docker daemon as a non-root user (check [Rootless mode](https://docs.docker.com/engine/security/rootless/) for more details). For it, follow the following steps:
+
+1. Install uidmap:
+    ``` bash
+    $ sudo apt-get install -y uidmap
+    ```
+
+1. If you installed Docker 20.10 or later with RPM/DEB packages, you should have `dockerd-rootless-setuptool.sh` in /usr/bin. Run `dockerd-rootless-setuptool.sh install` as a non-root user to set up the daemon:
+
+    ``` bash
+    $ dockerd-rootless-setuptool.sh install
+    [INFO] Creating /home/testuser/.config/systemd/user/docker.service
+    ...
+    [INFO] Installed docker.service successfully.
+    [INFO] To control docker.service, run: `systemctl --user (start|stop|restart) docker.service`
+    [INFO] To run docker.service on system startup, run: `sudo loginctl enable-linger testuser`
+
+    [INFO] Make sure the following environment variables are set (or add them to ~/.bashrc):
+
+    export PATH=/usr/bin:$PATH
+    export DOCKER_HOST=unix:///run/user/1000/docker.sock
+    ```
+
+1. Install the extra packages as well: 
+    ``` bash
+    $ sudo apt-get install -y docker-ce-rootless-extras`
+    ```
+
+1. Test it running: 
+    ``` bash
+    $ docker run hello-world
+    ```

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ An alternative option is to set it in a `.env` file, [pipenv loads .env into env
 1. `pipenv run build`
 1. `pipenv run tests`
 1. `pipenv run format`
-1. `pipenv run aws_pack`
+1. `pipenv run aws_lambda_pack`
 1. `gh pr create --title "brand new feature"`
 
 ### Writing Tests
@@ -56,50 +56,11 @@ This repository implments tests using [pytest](https://docs.pytest.org/), the te
 [^env_vars]: [For linux](https://www.gnu.org/software/bash/manual/bash.html#Environment) you can either prepend as in `NAME=value pipenv ...` or use `export NAME=value`, [for windows](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/set_1) you can use `set`.
 [^user_config]: A more detailed documentation on [the user configuration file can be found here](docs/user_configuration_file.md).
 
-## AWS Packing
-Since some services from infin-neat-core code runs at AWS cloud services, it's necessary to properly pack the code to upload it using the web interface, AWS CLI, or AWS CDK. 
+## AWS Lambda Packing
+In-fin-neat-core code runs on AWS Lambda and a "packing" command (`aws_lambda_pack`) is defined for generating a zip file with python dependencies (defined in Pipfile) installed to run on the AWS Lambda runtime.
 
-For that, on specific script has been created and can be run using pipenv: 
+The `aws_lambda_pack` command can be run using pipenv: 
 ```
-pipenv run aws_pack
+pipenv run aws_lambda_pack
 ```
-### Requirements:
-
-#### **Install Docker**: 
-Since in the packing processing Docker is used, it's necessary to install it. For installing Docker, the official documentation from Docker can be followed for [Linux](https://docs.docker.com/desktop/install/linux-install/), [Windows](https://docs.docker.com/desktop/install/windows-install/), and [MAC](https://docs.docker.com/desktop/install/mac-install/), 
-
-
-#### **Running Docker Rootless**: 
-
-Since the script uses **Docker** without root privileges, some extra steps are necessary to run the Docker daemon as a non-root user (check [Rootless mode](https://docs.docker.com/engine/security/rootless/) for more details). For it, follow the following steps:
-
-1. Install uidmap:
-    ``` bash
-    $ sudo apt-get install -y uidmap
-    ```
-
-1. If you installed Docker 20.10 or later with RPM/DEB packages, you should have `dockerd-rootless-setuptool.sh` in /usr/bin. Run `dockerd-rootless-setuptool.sh install` as a non-root user to set up the daemon:
-
-    ``` bash
-    $ dockerd-rootless-setuptool.sh install
-    [INFO] Creating /home/testuser/.config/systemd/user/docker.service
-    ...
-    [INFO] Installed docker.service successfully.
-    [INFO] To control docker.service, run: `systemctl --user (start|stop|restart) docker.service`
-    [INFO] To run docker.service on system startup, run: `sudo loginctl enable-linger testuser`
-
-    [INFO] Make sure the following environment variables are set (or add them to ~/.bashrc):
-
-    export PATH=/usr/bin:$PATH
-    export DOCKER_HOST=unix:///run/user/1000/docker.sock
-    ```
-
-1. Install the extra packages as well: 
-    ``` bash
-    $ sudo apt-get install -y docker-ce-rootless-extras`
-    ```
-
-1. Test it running: 
-    ``` bash
-    $ docker run hello-world
-    ```
+This script generates a requirements file using pipenv and install all dependencies in the `in_fin_core_package` zip file, created inside the `package` folder. This zip can be uploaded to aws lambda function.


### PR DESCRIPTION
A package creation for running in the AWS lambda system is necessary as part of the service's migration to the cloud. For that, a new script has been added to the pipenv file. This script installs all dependencies from the project and aws (boto3) and generates a zip file as a result.

This is a related task to [Epic] Transform features into a service with proper API #6