### PR TITLE
User token validation

### DIFF
--- a/personal_finances/user/jwt_utils.py
+++ b/personal_finances/user/jwt_utils.py
@@ -1,0 +1,30 @@
+from datetime import datetime, timedelta
+import os
+from typing import Any
+import boto3
+import jwt
+
+
+def _get_jwt_secret() -> str:
+    secret_name = os.environ["INFINEAT_JWT_SECRET_NAME"]
+    jwt_session = boto3.client("secretsmanager")
+    get_secret_value_response = jwt_session.get_secret_value(SecretId=secret_name)
+
+    return str(get_secret_value_response["SecretString"])
+
+
+def generate_token(user_id: str) -> str:
+    return jwt.encode(
+        {"exp": datetime.now() + timedelta(hours=1), "userId": user_id},
+        _get_jwt_secret(),
+        algorithm="HS256",
+    )
+
+
+def decode_token(token: str) -> Any:
+    return jwt.decode(
+        jwt=token,
+        key=_get_jwt_secret(),
+        algorithms=["HS256"],
+        options={"require": ["exp", "userId"]},
+    )

--- a/personal_finances/user/jwt_utils.py
+++ b/personal_finances/user/jwt_utils.py
@@ -1,10 +1,12 @@
 from datetime import datetime, timedelta
+from functools import cache
 import os
 from typing import Any
 import boto3
 import jwt
 
 
+@cache
 def _get_jwt_secret() -> str:
     secret_name = os.environ["INFINEAT_JWT_SECRET_NAME"]
     jwt_session = boto3.client("secretsmanager")

--- a/personal_finances/user/token_validation.py
+++ b/personal_finances/user/token_validation.py
@@ -1,6 +1,6 @@
-import base64
 import json
 import logging
+from typing import Any
 import boto3
 import jwt
 import os
@@ -8,65 +8,46 @@ import os
 LOGGER = logging.getLogger(__name__)
 
 
-class InvalidInput(Exception):
-    def __str__(self) -> str:
-        return "InvalidInput"
-
+class InvalidLambdaEventInput(Exception):
+    pass
 
 class AuthHeaderNotFound(Exception):
-    def __str__(self) -> str:
-        return "AuthHeaderNotFound"
-
-
-class UserNotFound(Exception):
-    def __str__(self) -> str:
-        return "UserNotFound"
+    pass
 
 
 class EmptyUserID(Exception):
-    def __str__(self) -> str:
-        return "EmptyUserID"
+    pass
 
 
-class TokenNotFound(Exception):
-    def __str__(self) -> str:
-        return "TokenNotFound"
+class AuthorizationHeaderEmptyContent(Exception):
+    pass
 
 
-def _get_token_from_event(event: dict):
+def _get_token_from_event(event: dict) -> Any:
     if "authorizationToken" not in event:
-        raise(AuthHeaderNotFound)
-    
+        raise (AuthHeaderNotFound)
+
     token = event.get("authorizationToken", None)
     if token is None or token == "":
-        raise(TokenNotFound)
-    
+        raise (AuthorizationHeaderEmptyContent)
+
     return token
 
 
 def _get_jwt_secret() -> str:
     jwt_session = boto3.client("secretsmanager")
+    secret_id = os.environ["INFINEAT_JWT_SECRET_NAME"]
 
-    get_secret_value_response = jwt_session.get_secret_value(
-        SecretId=os.environ["INFINEAT_JWT_SECRET_NAME"]
-    )
+    get_secret_value_response = jwt_session.get_secret_value(SecretId=secret_id)
 
     return str(get_secret_value_response["SecretString"])
 
 
-def decode_token(token):
-    return jwt.decode(
-        jwt=token,
-        key=_get_jwt_secret(),
-        algorithms="HS256",
-    )
-
-
-def _generatePolicy(principalId, effect, resource):
-    authResponse = {}
+def _generatePolicy(principalId: str, effect: str, resource: str) -> str:
+    authResponse: dict = {}
     authResponse["principalId"] = principalId
     if effect and resource:
-        policyDocument = {}
+        policyDocument: dict = {}
         policyDocument["Statement"] = []
         statementOne = {}
         statementOne["Action"] = "execute-api:Invoke"
@@ -77,22 +58,26 @@ def _generatePolicy(principalId, effect, resource):
     authResponse_JSON = json.dumps(authResponse)
     return authResponse_JSON
 
-def _get_user_from_decoded_token(token:dict) -> str:
-    if "userId" not in token:
-        raise(UserNotFound)
-    
-    user_id = token.get("userId", None)
+
+def _get_user_from_decoded_token(token: dict) -> str:
+    user_id: str = token.get("userId", None)
     if user_id is None or user_id == "":
-        raise(EmptyUserID)
-    
+        raise (EmptyUserID)
+
     return user_id
 
-def token_validation(event, context):
-    if event is None or event == "":
-        raise(InvalidInput)
-    
+
+def token_validation(event: dict, context: str) -> Any:
+    if event is None or event == {}:
+        raise (InvalidLambdaEventInput)
+
     token = _get_token_from_event(event)
-    decoded_token = jwt.decode(jwt=token, key=_get_jwt_secret(), algorithms="HS256", options={"require": ["exp", "userId"]})
+    decoded_token = jwt.decode(
+        jwt=token,
+        key=_get_jwt_secret(),
+        algorithms=["HS256"],
+        options={"require": ["exp", "userId"]},
+    )
     user_id = _get_user_from_decoded_token(decoded_token)
     response = _generatePolicy(user_id, "Allow", event["methodArn"])
 

--- a/personal_finances/user/token_validation.py
+++ b/personal_finances/user/token_validation.py
@@ -1,0 +1,99 @@
+import base64
+import json
+import logging
+import boto3
+import jwt
+import os
+
+LOGGER = logging.getLogger(__name__)
+
+
+class InvalidInput(Exception):
+    def __str__(self) -> str:
+        return "InvalidInput"
+
+
+class AuthHeaderNotFound(Exception):
+    def __str__(self) -> str:
+        return "AuthHeaderNotFound"
+
+
+class UserNotFound(Exception):
+    def __str__(self) -> str:
+        return "UserNotFound"
+
+
+class EmptyUserID(Exception):
+    def __str__(self) -> str:
+        return "EmptyUserID"
+
+
+class TokenNotFound(Exception):
+    def __str__(self) -> str:
+        return "TokenNotFound"
+
+
+def _get_token_from_event(event: dict):
+    if "authorizationToken" not in event:
+        raise(AuthHeaderNotFound)
+    
+    token = event.get("authorizationToken", None)
+    if token is None or token == "":
+        raise(TokenNotFound)
+    
+    return token
+
+
+def _get_jwt_secret() -> str:
+    jwt_session = boto3.client("secretsmanager")
+
+    get_secret_value_response = jwt_session.get_secret_value(
+        SecretId=os.environ["INFINEAT_JWT_SECRET_NAME"]
+    )
+
+    return str(get_secret_value_response["SecretString"])
+
+
+def decode_token(token):
+    return jwt.decode(
+        jwt=token,
+        key=_get_jwt_secret(),
+        algorithms="HS256",
+    )
+
+
+def _generatePolicy(principalId, effect, resource):
+    authResponse = {}
+    authResponse["principalId"] = principalId
+    if effect and resource:
+        policyDocument = {}
+        policyDocument["Statement"] = []
+        statementOne = {}
+        statementOne["Action"] = "execute-api:Invoke"
+        statementOne["Effect"] = effect
+        statementOne["Resource"] = resource
+        policyDocument["Statement"] = [statementOne]
+        authResponse["policyDocument"] = policyDocument
+    authResponse_JSON = json.dumps(authResponse)
+    return authResponse_JSON
+
+def _get_user_from_decoded_token(token:dict) -> str:
+    if "userId" not in token:
+        raise(UserNotFound)
+    
+    user_id = token.get("userId", None)
+    if user_id is None or user_id == "":
+        raise(EmptyUserID)
+    
+    return user_id
+
+def token_validation(event, context):
+    if event is None or event == "":
+        raise(InvalidInput)
+    
+    token = _get_token_from_event(event)
+    decoded_token = jwt.decode(jwt=token, key=_get_jwt_secret(), algorithms="HS256", options={"require": ["exp", "userId"]})
+    user_id = _get_user_from_decoded_token(decoded_token)
+    response = _generatePolicy(user_id, "Allow", event["methodArn"])
+
+    return json.loads(response)

--- a/tests/user/test_token_validation.py
+++ b/tests/user/test_token_validation.py
@@ -1,0 +1,188 @@
+import base64
+from datetime import datetime, timedelta, timezone
+import json
+import jwt
+import pytest
+from unittest.mock import Mock, patch
+from typing import Generator, Union
+from personal_finances.user.token_validation import (
+    token_validation,
+    InvalidInput,
+    AuthHeaderNotFound,
+    UserNotFound,
+    EmptyUserID,
+    TokenNotFound,
+)
+
+
+TEST_USER_ID = "testuser"
+TEST_USER_PASSWORD = "123"
+TEST_JWT_SECRET = "jwt_secret"
+TEST_ENVAR_DICT = {
+    "INFINEAT_JWT_SECRET_NAME": "jwt_secret",
+}
+
+
+def _get_input_without_auth_token() -> dict:
+    return {
+        "type": "TOKEN",
+        "methodArn": "arn:aws:execute-api:regionId:accountId:apiId/stage/httpVerb/[resource/[child-resources]]",
+    }
+
+
+def _get_input_event(token: str):
+    response = _get_input_without_auth_token()
+    response["authorizationToken"] = token
+    return response
+
+
+def _encode_basic_auth(user: str, password: str) -> str:
+    credentials = f"{user}:{password}"
+    credentials_encoded = credentials.encode()
+    authorization_encoded = base64.b64encode(credentials_encoded)
+    authorization = f"Basic {authorization_encoded.decode()}"
+    return authorization
+
+
+@pytest.fixture(autouse=True)
+def os_mock() -> Generator[Mock, None, None]:
+    with patch("personal_finances.user.token_validation.os") as mock:
+        yield mock
+
+
+@pytest.fixture(autouse=True)
+def boto3_mock() -> Generator[Mock, None, None]:
+    with patch("personal_finances.user.token_validation.boto3.client") as mock:
+        yield mock
+
+
+def _generate_jwt_token(exp_date: datetime, secret: str, user_name: str) -> str:
+    return jwt.encode(
+        {"exp": exp_date, "userId": user_name},
+        secret,
+        algorithm="HS256",
+    )
+
+
+def _gen_jwt_without_name(exp_date: datetime, secret: str):
+    return jwt.encode(
+        {"exp": exp_date},
+        secret,
+        algorithm="HS256",
+    )
+
+
+def _gen_jwt_without_exp_date(user_name: str, secret: str):
+    return jwt.encode(
+        {"userId": user_name},
+        secret,
+        algorithm="HS256",
+    )
+
+
+def _generate_jwt_token(exp_date: datetime, secret: str, user_id: str) -> str:
+    return jwt.encode(
+        {"exp": exp_date, "userId": user_id},
+        secret,
+        algorithm="HS256",
+    )
+
+
+@pytest.mark.parametrize(
+    "environment_variables, request_input, expected_exception",
+    [
+        (TEST_ENVAR_DICT, "", InvalidInput),
+        (TEST_ENVAR_DICT, None, InvalidInput),
+        (TEST_ENVAR_DICT, _get_input_without_auth_token(), AuthHeaderNotFound),
+        (TEST_ENVAR_DICT, _get_input_event(token=""), TokenNotFound),
+        (
+            TEST_ENVAR_DICT,
+            _get_input_event("invalid_token"),
+            jwt.exceptions.DecodeError,
+        ),
+        (
+            TEST_ENVAR_DICT,
+            _get_input_event(
+                _gen_jwt_without_exp_date(
+                    secret=TEST_JWT_SECRET, user_name=TEST_USER_ID
+                )
+            ),
+            jwt.exceptions.MissingRequiredClaimError,
+        ),
+        (
+            TEST_ENVAR_DICT,
+            _get_input_event(
+                _gen_jwt_without_name(exp_date=datetime.now(), secret=TEST_JWT_SECRET)
+            ),
+            jwt.exceptions.MissingRequiredClaimError,
+        ),
+        (
+            TEST_ENVAR_DICT,
+            _get_input_event(
+                _generate_jwt_token(
+                    exp_date="", secret=TEST_JWT_SECRET, user_id=TEST_USER_ID
+                )
+            ),
+            jwt.exceptions.DecodeError,
+        ),
+        (
+            TEST_ENVAR_DICT,
+            _get_input_event(
+                _generate_jwt_token(
+                    exp_date=datetime.now(), secret=TEST_JWT_SECRET, user_id=""
+                )
+            ),
+            EmptyUserID,
+        ),
+        (
+            TEST_ENVAR_DICT,
+            _get_input_event(
+                _generate_jwt_token(
+                    exp_date=datetime.now(),
+                    secret="invalid_secret",
+                    user_id=TEST_USER_ID,
+                )
+            ),
+            jwt.exceptions.InvalidSignatureError,
+        ),
+        (
+            TEST_ENVAR_DICT,
+            _get_input_event(
+                _generate_jwt_token(
+                    exp_date=datetime.now(timezone.utc) - timedelta(seconds=1),
+                    secret=TEST_JWT_SECRET,
+                    user_id=TEST_USER_ID,
+                )
+            ),
+            jwt.exceptions.ExpiredSignatureError,
+        ),
+        (
+            KeyError,
+            _get_input_event(
+                _generate_jwt_token(
+                    exp_date=datetime.now(),
+                    secret=TEST_JWT_SECRET,
+                    user_id=TEST_USER_ID,
+                )
+            ),
+            KeyError,
+        ),
+    ],
+)
+def test_token_validation_erros(
+    environment_variables: Union[dict, Exception],
+    request_input: str,
+    expected_exception: Exception,
+    os_mock: Mock,
+    boto3_mock: Mock,
+) -> None:
+    if isinstance(environment_variables, dict):
+        os_mock.environ.__getitem__.side_effect = environment_variables.get
+    else:
+        os_mock.environ.__getitem__.side_effect = environment_variables
+
+    aws_client_mock = boto3_mock.return_value
+    aws_client_mock.get_secret_value.return_value = {"SecretString": TEST_JWT_SECRET}
+
+    with pytest.raises(expected_exception=expected_exception):
+        token_validation(request_input, "")

--- a/tests/user/test_token_validation.py
+++ b/tests/user/test_token_validation.py
@@ -6,10 +6,7 @@ from unittest.mock import Mock, patch
 from typing import Generator, Type, Union
 from personal_finances.user.token_validation import (
     token_validation,
-    InvalidLambdaEventInput,
-    AuthHeaderNotFound,
-    EmptyUserID,
-    AuthorizationHeaderEmptyContent,
+    InvalidLambdaEventInput
 )
 
 
@@ -20,7 +17,7 @@ TEST_ENVAR_DICT = {
     "INFINEAT_JWT_SECRET_NAME": TEST_JWT_SECRET,
 }
 
-TEST_RESULT_OK = {
+EXPECTED_ALLOW_POLICY = {
     "policyDocument": {
         "Statement": [
             {
@@ -79,87 +76,22 @@ def _generate_jwt_token(
 
 @pytest.fixture(autouse=True)
 def boto3_mock() -> Generator[Mock, None, None]:
-    with patch("personal_finances.user.token_validation.boto3.client") as mock:
+    with patch("personal_finances.user.jwt_utils.boto3.client") as mock:
         yield mock
 
 
 @pytest.fixture(autouse=True)
 def jwt_datetime_mock() -> Generator[Mock, None, None]:
-    with patch("personal_finances.user.token_validation.jwt.api_jwt.datetime") as mock:
+    with patch("personal_finances.user.jwt_utils.jwt.api_jwt.datetime") as mock:
         mock.now.return_value = TEST_DATE_TIME_NOW_MOCK
         yield mock
 
 
 @pytest.mark.parametrize(
-    "environment_variables, request_input, expected_exception_r",
+    "environment_variables, request_input, expected_exception",
     [
         (TEST_ENVAR_DICT, {}, InvalidLambdaEventInput),
         (TEST_ENVAR_DICT, None, InvalidLambdaEventInput),
-        (TEST_ENVAR_DICT, _get_input_without_auth_token(), AuthHeaderNotFound),
-        (TEST_ENVAR_DICT, _get_input_event(token=""), AuthorizationHeaderEmptyContent),
-        (
-            TEST_ENVAR_DICT,
-            _get_input_event("invalid_token"),
-            jwt.exceptions.DecodeError,
-        ),
-        (
-            TEST_ENVAR_DICT,
-            _get_input_event(
-                _gen_jwt_without_exp_date(secret=TEST_JWT_SECRET, user_id=TEST_USER_ID)
-            ),
-            jwt.exceptions.MissingRequiredClaimError,
-        ),
-        (
-            TEST_ENVAR_DICT,
-            _get_input_event(
-                _gen_jwt_without_name(
-                    exp_date=TEST_NOT_EXPIRED_DATE_TIME, secret=TEST_JWT_SECRET
-                )
-            ),
-            jwt.exceptions.MissingRequiredClaimError,
-        ),
-        (
-            TEST_ENVAR_DICT,
-            _get_input_event(
-                _generate_jwt_token(
-                    exp_date="", secret=TEST_JWT_SECRET, user_id=TEST_USER_ID
-                )
-            ),
-            jwt.exceptions.DecodeError,
-        ),
-        (
-            TEST_ENVAR_DICT,
-            _get_input_event(
-                _generate_jwt_token(
-                    exp_date=TEST_NOT_EXPIRED_DATE_TIME,
-                    secret=TEST_JWT_SECRET,
-                    user_id="",
-                )
-            ),
-            EmptyUserID,
-        ),
-        (
-            TEST_ENVAR_DICT,
-            _get_input_event(
-                _generate_jwt_token(
-                    exp_date=TEST_NOT_EXPIRED_DATE_TIME,
-                    secret="invalid_secret",
-                    user_id=TEST_USER_ID,
-                )
-            ),
-            jwt.exceptions.InvalidSignatureError,
-        ),
-        (
-            TEST_ENVAR_DICT,
-            _get_input_event(
-                _generate_jwt_token(
-                    exp_date=TEST_EXPIRED_DATE_TIME,
-                    secret=TEST_JWT_SECRET,
-                    user_id=TEST_USER_ID,
-                )
-            ),
-            jwt.exceptions.ExpiredSignatureError,
-        ),
         (
             {},
             _get_input_event(
@@ -173,20 +105,93 @@ def jwt_datetime_mock() -> Generator[Mock, None, None]:
         ),
     ],
 )
-def test_token_validation_errors(
+def test_token_validation_exceptions(
     environment_variables: dict,
     request_input: dict,
-    expected_exception_r: Type[Exception],
+    expected_exception: Type[Exception],
     boto3_mock: Mock,
 ) -> None:
 
     aws_client_mock = boto3_mock.return_value
     aws_client_mock.get_secret_value.return_value = {"SecretString": TEST_JWT_SECRET}
 
-    with pytest.raises(expected_exception_r), patch.dict(
+    with pytest.raises(expected_exception), patch.dict(
         os.environ, environment_variables
     ):
         token_validation(request_input, "")
+
+
+@pytest.mark.parametrize(
+    "environment_variables, request_input",
+    [
+        (TEST_ENVAR_DICT, _get_input_without_auth_token()),
+        (TEST_ENVAR_DICT, _get_input_event(token="")),
+        (TEST_ENVAR_DICT, _get_input_event("invalid_token")),
+        (
+            TEST_ENVAR_DICT,
+            _get_input_event(
+                _gen_jwt_without_exp_date(secret=TEST_JWT_SECRET, user_id=TEST_USER_ID)
+            ),
+        ),
+        (
+            TEST_ENVAR_DICT,
+            _get_input_event(
+                _gen_jwt_without_name(
+                    exp_date=TEST_NOT_EXPIRED_DATE_TIME, secret=TEST_JWT_SECRET
+                )
+            ),
+        ),
+        (
+            TEST_ENVAR_DICT,
+            _get_input_event(
+                _generate_jwt_token(
+                    exp_date="", secret=TEST_JWT_SECRET, user_id=TEST_USER_ID
+                )
+            ),
+        ),
+        (
+            TEST_ENVAR_DICT,
+            _get_input_event(
+                _generate_jwt_token(
+                    exp_date=TEST_NOT_EXPIRED_DATE_TIME,
+                    secret=TEST_JWT_SECRET,
+                    user_id="",
+                )
+            ),
+        ),
+        (
+            TEST_ENVAR_DICT,
+            _get_input_event(
+                _generate_jwt_token(
+                    exp_date=TEST_NOT_EXPIRED_DATE_TIME,
+                    secret="invalid_secret",
+                    user_id=TEST_USER_ID,
+                )
+            ),
+        ),
+        (
+            TEST_ENVAR_DICT,
+            _get_input_event(
+                _generate_jwt_token(
+                    exp_date=TEST_EXPIRED_DATE_TIME,
+                    secret=TEST_JWT_SECRET,
+                    user_id=TEST_USER_ID,
+                )
+            ),
+        ),
+    ],
+)
+def test_invalid_tokens(
+    environment_variables: dict,
+    request_input: dict,
+    boto3_mock: Mock,
+) -> None:
+
+    aws_client_mock = boto3_mock.return_value
+    aws_client_mock.get_secret_value.return_value = {"SecretString": TEST_JWT_SECRET}
+
+    with patch.dict(os.environ, environment_variables):
+        assert "unauthorized" == token_validation(request_input, "")
 
 
 @pytest.mark.parametrize(
@@ -201,7 +206,7 @@ def test_token_validation_errors(
                     user_id=TEST_USER_ID,
                 )
             ),
-            TEST_RESULT_OK,
+            EXPECTED_ALLOW_POLICY,
         ),
     ],
 )

--- a/tests/user/test_user_auth.py
+++ b/tests/user/test_user_auth.py
@@ -31,14 +31,6 @@ TEST_ENVAR_DICT = {
 }
 
 
-def _encode_basic_auth(user: str, password: str) -> str:
-    credentials = f"{user}:{password}"
-    credentials_encoded = credentials.encode()
-    authorization_encoded = base64.b64encode(credentials_encoded)
-    authorization = f"Basic {authorization_encoded.decode()}"
-    return authorization
-
-
 @pytest.fixture(autouse=True)
 def boto3_client_mock() -> Generator[Mock, None, None]:
     with patch("personal_finances.user.user_auth.boto3.client") as mock:
@@ -52,8 +44,8 @@ def boto3_resource_mock() -> Generator[Mock, None, None]:
 
 
 @pytest.fixture(autouse=True)
-def datetime_mock() -> Generator[Mock, None, None]:
-    with patch("personal_finances.user.user_auth.datetime") as mock:
+def jwt_datetime_utils_mock() -> Generator[Mock, None, None]:
+    with patch("personal_finances.user.jwt_utils.datetime") as mock:
         mock.now.return_value = TEST_DATE_TIME_NOW
         yield mock
 
@@ -64,6 +56,14 @@ def _generate_test_jwt_token() -> str:
         TEST_JWT_SECRETS,
         algorithm="HS256",
     )
+
+
+def _encode_basic_auth(user: str, password: str) -> str:
+    credentials = f"{user}:{password}"
+    credentials_encoded = credentials.encode()
+    authorization_encoded = base64.b64encode(credentials_encoded)
+    authorization = f"Basic {authorization_encoded.decode()}"
+    return authorization
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR creates a user token validation feature for the https://github.com/in-fin-neat/in-fin-neat-core/issues/38 issue.
This token validation will be integrated with [AWS API Gateway as a lambda authorizer](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-use-lambda-authorizer.html). The purpose is to return to the API gateway if the token is valid and if the user is allowed to access the resource from the request.

Since we do not have any authorization rules established, the response is "allow" to API Gateway if the token is valid. Otherwise, it returns an exception, and API Gateway will convert that to a `500 Invalid token` as a response for the end user.

The token verified is a JWT token. Integration with the Secrets manager was also necessary to get the secret token name.