### PR TITLE
Adding configuration for CORS domain in API response

### DIFF
--- a/personal_finances/user/user_auth.py
+++ b/personal_finances/user/user_auth.py
@@ -81,8 +81,22 @@ def _password_match(recv_password: str, stored_password: str) -> bool:
         return False
 
 
+def get_allowed_domain() -> str:
+    # TODO: allow for multiple origins
+    # fetching only the first origin
+    try:
+        allowed_domain = os.environ["ALLOWED_ORIGIN_DOMAINS"].split(",")[0]
+    except Exception as e:
+        LOGGER.info(f"falling 'ALLOWED_ORIGIN_DOMAINS' back to * due to: {e}")
+        return "*"
+    return allowed_domain if allowed_domain else "*"
+
+
 def add_cors_to_dict(input_dict: dict) -> dict:
-    return {**input_dict, "headers": {"Access-Control-Allow-Origin": "*"}}
+    return {
+        **input_dict,
+        "headers": {"Access-Control-Allow-Origin": get_allowed_domain()},
+    }
 
 
 def _check_user_id_constraints(user: str) -> None:

--- a/tests/user/test_user_auth.py
+++ b/tests/user/test_user_auth.py
@@ -26,9 +26,12 @@ TEST_USER_DYNAMO_RESPONSE = {
 
 TEST_JWT_SECRETS = "jwt_secret"
 TEST_DATE_TIME_NOW = datetime(2060, 1, 1, 10, 00, 00)
+
+TEST_ALLOWED_ORIGINS = {"ALLOWED_ORIGIN_DOMAINS": "some-test-domain"}
 TEST_ENVAR_DICT = {
     "INFINEAT_DYNAMODB_USER_TABLE_NAME": "table_name",
     "INFINEAT_JWT_SECRET_NAME": "jwt_secret",
+    **TEST_ALLOWED_ORIGINS,
 }
 
 
@@ -126,7 +129,7 @@ def _encode_basic_auth(user: str, password: str) -> str:
                 ),
             },
             {},
-            {},
+            TEST_ALLOWED_ORIGINS,
         ),
         (
             {"headers": {"Authorization": _encode_basic_auth("dummy_user", "pass")}},
@@ -138,7 +141,7 @@ def _encode_basic_auth(user: str, password: str) -> str:
                 ),
             },
             {},
-            {},
+            TEST_ALLOWED_ORIGINS,
         ),
         (
             {},
@@ -186,7 +189,7 @@ def _encode_basic_auth(user: str, password: str) -> str:
                 "body": "Internal Server Error",
             },
             TEST_USER_DYNAMO_RESPONSE,
-            {},
+            TEST_ALLOWED_ORIGINS,
         ),
         (
             {
@@ -225,8 +228,8 @@ def test_user_auth(
 
     with patch.dict(os.environ, env_var_dict):
         response = user_handler(test_event_input, "")
+        assert response == add_cors_to_dict(expected_response)
 
-    assert response == add_cors_to_dict(expected_response)
     if expected_response["statusCode"] == 200:
         token = json.loads(response["body"])["token"]
         try:


### PR DESCRIPTION
We're allowing all domains as our CORS policy, that's not a safe strategy and browsers would complain about that.

This PR adds a simple single origin answer for CORs policy. A multi-origin logic would need an extra auth layer checking domins (more here https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin)