### PR TITLE
Issue 18: if datetime is in naive format, converts to aware

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ boto3 = "*"
 decorator = "*"
 schwifty = "*"
 pydantic ="*"
+pytz ="*"
 
 [dev-packages]
 pytest = "*"

--- a/personal_finances/generate_reports.py
+++ b/personal_finances/generate_reports.py
@@ -219,6 +219,12 @@ def generate_reports(
     try:
         start_datetime = dateutil.parser.isoparse(start_time)
         end_datetime = dateutil.parser.isoparse(end_time)
+
+        if start_datetime.tzinfo is None:
+            start_datetime = dateutil.parser.isoparse(start_time+" 00:00+00:00")
+        if end_datetime.tzinfo is None:
+            end_datetime = dateutil.parser.isoparse(end_time+" 00:00+00:00")
+
     except ValueError as e:
         raise InvalidDatetime(e)
 

--- a/personal_finances/generate_reports.py
+++ b/personal_finances/generate_reports.py
@@ -1,4 +1,5 @@
 import json
+import pytz
 from datetime import datetime
 from personal_finances.bank_interface.nordigen_adapter import as_simple_transaction
 from personal_finances.transaction.grouping import (
@@ -221,9 +222,11 @@ def generate_reports(
         end_datetime = dateutil.parser.isoparse(end_time)
 
         if start_datetime.tzinfo is None:
-            start_datetime = dateutil.parser.isoparse(start_time+" 00:00+00:00")
+            timezone = pytz.timezone("UTC")
+            start_datetime = timezone.localize(start_datetime)
         if end_datetime.tzinfo is None:
-            end_datetime = dateutil.parser.isoparse(end_time+" 00:00+00:00")
+            timezone = pytz.timezone("UTC")
+            end_datetime = timezone.localize(end_datetime)
 
     except ValueError as e:
         raise InvalidDatetime(e)

--- a/tests/test_generate_reports.py
+++ b/tests/test_generate_reports.py
@@ -108,6 +108,51 @@ def test_malformed_cli_params_rejected(
             "/path/to/my/user_config.yaml",
             "data/merged_transactions_latest.json",
         ),
+        (
+            ["-st", "2010-01-01", "-et", "2023-01-01T00:00:01Z"],
+            "config/user_config.yaml",
+            "data/merged_transactions_latest.json",
+        ),
+        (
+            ["-st", "2010-01-01T00:00:00Z", "-et", "2023-01-01"],
+            "config/user_config.yaml",
+            "data/merged_transactions_latest.json",
+        ),
+        (
+            ["-st", "2010-01-01", "-et", "2023-01-01"],
+            "config/user_config.yaml",
+            "data/merged_transactions_latest.json",
+        ),
+        (
+            [
+                "--start-time",
+                "2010-01-01",
+                "--end-time",
+                "2023-01-01T00:00:01Z",
+            ],
+            "config/user_config.yaml",
+            "data/merged_transactions_latest.json",
+        ),
+        (
+            [
+                "--start-time",
+                "2010-01-01T00:00:00Z",
+                "--end-time",
+                "2023-01-01",
+            ],
+            "config/user_config.yaml",
+            "data/merged_transactions_latest.json",
+        ),
+        (
+            [
+                "--start-time",
+                "2010-01-01",
+                "--end-time",
+                "2023-01-01",
+            ],
+            "config/user_config.yaml",
+            "data/merged_transactions_latest.json",
+        ),
     ],
 )
 def test_correct_cli_params(


### PR DESCRIPTION
- Added forced timezone information to generate_reports().
- Added 6 test cases (using -ST/-ET and -start-time/-end-time not providing timezone for the three combinations on each case)