### PR TITLE
Adjust the user api to always return JSON type in the http body

### DIFF
--- a/personal_finances/user/user_auth_exceptions.py
+++ b/personal_finances/user/user_auth_exceptions.py
@@ -57,7 +57,7 @@ class InvalidIban(Exception):
 _EXCEPTION_TO_HTTP_RESPONSE: Dict[Tuple, Dict] = {
     (UserNotFound, PasswordNotMatch): {
         "statusCode": 401,
-        "body": "User or password incorrect",
+        "body": '{"message": "User or password incorrect"}',
     },
     (
         AuthorizationHeaderNotPresent,
@@ -65,31 +65,29 @@ _EXCEPTION_TO_HTTP_RESPONSE: Dict[Tuple, Dict] = {
         InvalidAuthorizationHeader,
     ): {
         "statusCode": 400,
-        "body": "Invalid authentication input",
+        "body": '{"message": "Invalid authentication input"}',
     },
     (InvalidIban,): {
         "statusCode": 400,
-        "body": "Invalid IBAN format",
+        "body": '{"message": "Invalid IBAN format"}',
     },
     (
         InvalidUserPassword,
         InvalidUserName,
     ): {
         "statusCode": 400,
-        "body": "Username or password does not match the minimal security requirements",
+        "body": '{"message": "Username or password does not '
+        + 'match the minimal security requirements"}',
     },
-    (
-        InvalidDynamoResponse,
-        InvalidLambdaEventInput
-    ): {
+    (InvalidDynamoResponse, InvalidLambdaEventInput): {
         "statusCode": 500,
-        "body": "Internal Server Error",
+        "body": '{"message": "Internal Server Error"}',
     },
 }
 
 _UNKNOWN_EXCEPTION_RESPONSE: Dict = {
     "statusCode": 500,
-    "body": "Internal Server Error",
+    "body": '{"message": "Internal Server Error"}',
 }
 
 

--- a/personal_finances/user/user_service.py
+++ b/personal_finances/user/user_service.py
@@ -57,7 +57,7 @@ def add_cors_decorator(handler: Callable, *args: Any, **kwargs: Any) -> dict:
 def user_service_handler(event: dict, context: str) -> dict:
     resource = event["resource"]
     http_method = event["httpMethod"]
-
+    response = {}
     logging.info(f"info_event:{event}")
     logging.info(f"info_context:{context}")
 
@@ -65,12 +65,15 @@ def user_service_handler(event: dict, context: str) -> dict:
         if resource == "/users/{userId}/login" and http_method == "POST":
             auth_header = _get_auth_header(event)
             token_json = user_login(auth_header)
-            return {"statusCode": 200, "body": f"{token_json}"}
+            response["token"] = token_json
+            return {"statusCode": 200, "body": f"{json.dumps(response)}"}
 
         elif resource == "/users/{userId}/bank-accounts" and http_method == "GET":
             user_id = event["pathParameters"].get("userId")
             iban_list = get_user_ibans(user_id)
-            return {"statusCode": 200, "body": f"ibanList:{json.dumps(iban_list)}"}
+            response_iban = {}
+            response_iban["ibanList"] = iban_list
+            return {"statusCode": 200, "body": f"{json.dumps(response_iban)}"}
 
         elif (
             resource == "/users/{userId}/bank-accounts/{iban}" and http_method == "PUT"
@@ -78,10 +81,12 @@ def user_service_handler(event: dict, context: str) -> dict:
             iban = event["pathParameters"].get("iban")
             user_id = event["pathParameters"].get("userId")
             update_user_iban(user_id, iban)
-            return {"statusCode": 200, "body": "IBAN added successfully"}
+            response["message"] = "IBAN added successfully"
+            return {"statusCode": 200, "body": f"{json.dumps(response)}"}
 
         # Default response for unknown paths/methods
-        return {"statusCode": 404, "body": "Not Found"}
+        response["message"] = "Not Found"
+        return {"statusCode": 404, "body": f"{json.dumps(response)}"}
 
     except Exception as e:
         LOGGER.exception(

--- a/tests/user/test_user_auth_exceptions.py
+++ b/tests/user/test_user_auth_exceptions.py
@@ -17,7 +17,7 @@ from personal_finances.user.user_auth_exceptions import (
 _TEST_DUPLICATED_EXCEPTION_TO_HTTP_RESPONSE: Dict[Tuple, Dict] = {
     (UserNotFound, PasswordNotMatch): {
         "statusCode": 401,
-        "body": "User or password incorrect",
+        "body": '{"message": "User or password incorrect"}',
     },
     (
         AuthorizationHeaderNotPresent,
@@ -25,13 +25,13 @@ _TEST_DUPLICATED_EXCEPTION_TO_HTTP_RESPONSE: Dict[Tuple, Dict] = {
         InvalidAuthorizationHeader,
     ): {
         "statusCode": 400,
-        "body": "Invalid authentication input",
+        "body": '{"message": "Invalid authentication input"}',
     },
 }
 
 _TEST_EMPTY_EXCEPTION_LIST_RESPONSE: Dict = {
     "statusCode": 500,
-    "body": "Internal Server Error",
+    "body": '{"message": "Internal Server Error"}',
 }
 
 
@@ -40,31 +40,31 @@ _TEST_EMPTY_EXCEPTION_LIST_RESPONSE: Dict = {
     [
         (
             UserNotFound,
-            {"statusCode": 401, "body": "User or password incorrect"},
+            {"statusCode": 401, "body": '{"message": "User or password incorrect"}'},
         ),
         (
             PasswordNotMatch,
-            {"statusCode": 401, "body": "User or password incorrect"},
+            {"statusCode": 401, "body": '{"message": "User or password incorrect"}'},
         ),
         (
             AuthorizationHeaderNotPresent,
-            {"statusCode": 400, "body": "Invalid authentication input"},
+            {"statusCode": 400, "body": '{"message": "Invalid authentication input"}'},
         ),
         (
             AuthorizationHeaderEmptyContent,
-            {"statusCode": 400, "body": "Invalid authentication input"},
+            {"statusCode": 400, "body": '{"message": "Invalid authentication input"}'},
         ),
         (
             InvalidAuthorizationHeader,
-            {"statusCode": 400, "body": "Invalid authentication input"},
+            {"statusCode": 400, "body": '{"message": "Invalid authentication input"}'},
         ),
         (
             InvalidUserPassword,
             {
                 "statusCode": 400,
                 "body": (
-                    "Username or password does not "
-                    + "match the minimal security requirements"
+                    '{"message": "Username or password does not '
+                    + 'match the minimal security requirements"}'
                 ),
             },
         ),
@@ -73,26 +73,26 @@ _TEST_EMPTY_EXCEPTION_LIST_RESPONSE: Dict = {
             {
                 "statusCode": 400,
                 "body": (
-                    "Username or password does not "
-                    + "match the minimal security requirements"
+                    '{"message": "Username or password does not '
+                    + 'match the minimal security requirements"}'
                 ),
             },
         ),
         (
             InvalidLambdaEventInput,
-            {"statusCode": 500, "body": "Internal Server Error"},
+            {"statusCode": 500, "body": '{"message": "Internal Server Error"}'},
         ),
         (
             InvalidDynamoResponse,
-            {"statusCode": 500, "body": "Internal Server Error"},
+            {"statusCode": 500, "body": '{"message": "Internal Server Error"}'},
         ),
         (
             KeyError,
-            {"statusCode": 500, "body": "Internal Server Error"},
+            {"statusCode": 500, "body": '{"message": "Internal Server Error"}'},
         ),
         (
             Exception,
-            {"statusCode": 500, "body": "Internal Server Error"},
+            {"statusCode": 500, "body": '{"message": "Internal Server Error"}'},
         ),
     ],
 )

--- a/tests/user/test_user_service.py
+++ b/tests/user/test_user_service.py
@@ -48,7 +48,7 @@ def mock_update_user_iban() -> Any:
             },
             {
                 "statusCode": 500,
-                "body": "Internal Server Error",
+                "body": '{"message": "Internal Server Error"}',
                 "headers": {"Access-Control-Allow-Origin": "*"},
             },
         ),
@@ -57,7 +57,7 @@ def mock_update_user_iban() -> Any:
             {"resource": "/users/{userId}/login", "httpMethod": "POST", "headers": {}},
             {
                 "statusCode": 400,
-                "body": "Invalid authentication input",
+                "body": '{"message": "Invalid authentication input"}',
                 "headers": {"Access-Control-Allow-Origin": "*"},
             },
         ),
@@ -70,7 +70,7 @@ def mock_update_user_iban() -> Any:
             },
             {
                 "statusCode": 400,
-                "body": "Invalid authentication input",
+                "body": '{"message": "Invalid authentication input"}',
                 "headers": {"Access-Control-Allow-Origin": "*"},
             },
         ),
@@ -98,7 +98,7 @@ def test_get_auth_header_exceptions(
                 "httpMethod": "POST",
                 "headers": {"Authorization": "Bearer testtoken"},
             },
-            '{"token": "abc123"}',
+            "abc123",
             {
                 "statusCode": 200,
                 "body": '{"token": "abc123"}',
@@ -115,7 +115,7 @@ def test_get_auth_header_exceptions(
             UserNotFound(),
             {
                 "statusCode": 401,
-                "body": "User or password incorrect",
+                "body": '{"message": "User or password incorrect"}',
                 "headers": {"Access-Control-Allow-Origin": "*"},
             },
         ),
@@ -155,7 +155,7 @@ def test_user_service_handler_login(
             ["DE1234567890", "GB0987654321"],
             {
                 "statusCode": 200,
-                "body": 'ibanList:["DE1234567890", "GB0987654321"]',
+                "body": '{"ibanList": ["DE1234567890", "GB0987654321"]}',
                 "headers": {"Access-Control-Allow-Origin": "*"},
             },
         ),
@@ -169,7 +169,7 @@ def test_user_service_handler_login(
             UserNotFound(),
             {
                 "statusCode": 401,
-                "body": "User or password incorrect",
+                "body": '{"message": "User or password incorrect"}',
                 "headers": {"Access-Control-Allow-Origin": "*"},
             },
         ),
@@ -206,7 +206,7 @@ def test_user_service_handler_get_ibans(
             None,
             {
                 "statusCode": 200,
-                "body": "IBAN added successfully",
+                "body": '{"message": "IBAN added successfully"}',
                 "headers": {"Access-Control-Allow-Origin": "*"},
             },
         ),
@@ -221,7 +221,7 @@ def test_user_service_handler_get_ibans(
             InvalidIban(),
             {
                 "statusCode": 400,
-                "body": "Invalid IBAN format",
+                "body": '{"message": "Invalid IBAN format"}',
                 "headers": {"Access-Control-Allow-Origin": "*"},
             },
         ),
@@ -256,7 +256,7 @@ def test_user_service_handler_update_iban(
             },
             {
                 "statusCode": 404,
-                "body": "Not Found",
+                "body": '{"message": "Not Found"}',
                 "headers": {"Access-Control-Allow-Origin": "https://some-test-domain"},
             },
         ),
@@ -268,7 +268,7 @@ def test_user_service_handler_update_iban(
             },
             {
                 "statusCode": 404,
-                "body": "Not Found",
+                "body": '{"message": "Not Found"}',
                 "headers": {"Access-Control-Allow-Origin": "https://some-test-domain"},
             },
         ),
@@ -280,7 +280,7 @@ def test_user_service_handler_update_iban(
             },
             {
                 "statusCode": 404,
-                "body": "Not Found",
+                "body": '{"message": "Not Found"}',
                 "headers": {"Access-Control-Allow-Origin": "https://some-test-domain"},
             },
         ),
@@ -292,7 +292,7 @@ def test_user_service_handler_update_iban(
             },
             {
                 "statusCode": 404,
-                "body": "Not Found",
+                "body": '{"message": "Not Found"}',
                 "headers": {"Access-Control-Allow-Origin": "https://some-test-domain"},
             },
         ),
@@ -304,7 +304,7 @@ def test_user_service_handler_update_iban(
             },
             {
                 "statusCode": 404,
-                "body": "Not Found",
+                "body": '{"message": "Not Found"}',
                 "headers": {"Access-Control-Allow-Origin": "https://some-test-domain"},
             },
         ),
@@ -316,7 +316,7 @@ def test_user_service_handler_update_iban(
             },
             {
                 "statusCode": 404,
-                "body": "Not Found",
+                "body": '{"message": "Not Found"}',
                 "headers": {"Access-Control-Allow-Origin": "https://some-test-domain"},
             },
         ),
@@ -328,7 +328,7 @@ def test_user_service_handler_update_iban(
             },
             {
                 "statusCode": 404,
-                "body": "Not Found",
+                "body": '{"message": "Not Found"}',
                 "headers": {"Access-Control-Allow-Origin": "https://some-test-domain"},
             },
         ),
@@ -340,7 +340,7 @@ def test_user_service_handler_update_iban(
             },
             {
                 "statusCode": 404,
-                "body": "Not Found",
+                "body": '{"message": "Not Found"}',
                 "headers": {"Access-Control-Allow-Origin": "https://some-test-domain"},
             },
         ),


### PR DESCRIPTION
This PR is part of the [Configure user bank accounts in the cloud app](https://github.com/in-fin-neat/in-fin-neat-core/issues/38#top) #38 issue.

The current implementation of the API is missing some congruency since it's not returning all the body responses in JSON. 

This PR solves this issue, enforcing consistency by returning all responses in JSON format. 

