### PR TITLE
Format the bank authentication handler

### DIFF
--- a/personal_finances/bank_interface/bank_auth_handler.py
+++ b/personal_finances/bank_interface/bank_auth_handler.py
@@ -122,18 +122,23 @@ class BankAuthorizationHandler:
             user_id, requisition_validator
         ):
             LOGGER.debug("requisition store has valid requisitions")
-            return list(map(
-                lambda requisition_id: AuthorizationUrl.model_validate(
-                    {
-                        # These empty strings will be populated when requisition store
-                        # is transformed into URL store, it's needed for bank validation
-                        "authorization_url": "",
-                        "validation_reference": "",
-                        "payload": requisition_id,
-                    }
-                ),
-                self._requisition_store.get_last_requisitions(user_id).RequisitionIds,
-            ))
+            return list(
+                map(
+                    lambda requisition_id: AuthorizationUrl.model_validate(
+                        {
+                            # These empty strings will be populated when
+                            # requisition store is transformed into URL store,
+                            # it's needed for bank validation
+                            "authorization_url": "",
+                            "validation_reference": "",
+                            "payload": requisition_id,
+                        }
+                    ),
+                    self._requisition_store.get_last_requisitions(
+                        user_id
+                    ).RequisitionIds,
+                )
+            )
         else:
             LOGGER.debug("no valid requisitions stored, getting new requisitions")
             authorization_urls = list(


### PR DESCRIPTION
There are two PEP8 format violations in the bank authentication handler:

personal_finances/bank_interface/bank_auth_handler.py:129:89: E501 line too long (90 > 88 characters)
personal_finances/bank_interface/bank_auth_handler.py:130:89: E501 line too long (92 > 88 characters)

This PR solves it.