### PR TITLE
Change from list to set the ibans

### DIFF
--- a/personal_finances/user/user_auth_exceptions.py
+++ b/personal_finances/user/user_auth_exceptions.py
@@ -48,7 +48,7 @@ class InvalidIban(Exception):
     pass
 
 
-class ConditionalCheckFailedException(Exception):
+class UserIdNotInDatabase(Exception):
     pass
 
 
@@ -89,7 +89,7 @@ _EXCEPTION_TO_HTTP_RESPONSE: Dict[Tuple, Dict] = {
         "statusCode": 500,
         "body": "Internal Server Error",
     },
-    (ConditionalCheckFailedException,): {
+    (UserIdNotInDatabase,): {
         "statusCode": 400,
         "body": "Invalid User",
         },

--- a/personal_finances/user/user_auth_exceptions.py
+++ b/personal_finances/user/user_auth_exceptions.py
@@ -48,6 +48,10 @@ class InvalidIban(Exception):
     pass
 
 
+class ConditionalCheckFailedException(Exception):
+    pass
+
+
 """
     This dicts contains the map between the exceptions generated in
     the user login api and the http response. No exception should be
@@ -85,6 +89,10 @@ _EXCEPTION_TO_HTTP_RESPONSE: Dict[Tuple, Dict] = {
         "statusCode": 500,
         "body": "Internal Server Error",
     },
+    (ConditionalCheckFailedException,): {
+        "statusCode": 400,
+        "body": "Invalid User",
+        },
 }
 
 _UNKNOWN_EXCEPTION_RESPONSE: Dict = {

--- a/personal_finances/user/user_persistence.py
+++ b/personal_finances/user/user_persistence.py
@@ -11,7 +11,7 @@ from personal_finances.user.user_auth_exceptions import (
     UserNotFound,
     InvalidIban,
     InvalidDynamoResponse,
-    ConditionalCheckFailedException
+    UserIdNotInDatabase
 )
 from schwifty import IBAN
 from botocore.exceptions import ClientError
@@ -91,7 +91,7 @@ def update_user_iban(userId: str, newIban: str) -> None:
     except ClientError as e:
         if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
             LOGGER.info(f"response error: {e.response}")
-            raise ConditionalCheckFailedException(f"userId not found: {userId}")
+            raise UserIdNotInDatabase(f"userId not found: {userId}")
         else:
             raise Exception(f"Update user iban error: {e.response}")
 

--- a/personal_finances/user/user_persistence.py
+++ b/personal_finances/user/user_persistence.py
@@ -2,7 +2,7 @@ from functools import cache
 import logging
 import boto3
 import os
-from typing import Any, List
+from typing import Any
 import boto3.dynamodb
 import boto3.dynamodb.table
 from pydantic import BaseModel, ValidationError
@@ -23,7 +23,7 @@ USER_PASSWORD_MIN_LEN = 6
 class User(BaseModel):
     userId: str
     password: str
-    ibanList: List[str]
+    ibanSet: set[str]
 
 
 @cache
@@ -50,7 +50,7 @@ def get_user_password(userId: str) -> str:
     return user.password
 
 
-def get_user_ibans(userId: str) -> List[str]:
+def get_user_ibans(userId: str) -> set[str]:
     table = _get_user_table()
 
     try:
@@ -61,7 +61,7 @@ def get_user_ibans(userId: str) -> List[str]:
             raise UserNotFound(f"User not found: {userId}")
 
         user = User(**response["Item"])
-        iban_list = user.ibanList
+        iban_list = user.ibanSet
 
         LOGGER.info(f"User IBAN list:{iban_list}")
         return iban_list
@@ -90,17 +90,12 @@ def update_user_iban(userId: str, newIban: str) -> None:
         LOGGER.error(f"Data validation error: {e}")
         raise InvalidDynamoResponse("Invalid data format from DynamoDB")
 
-    iban_list = user.ibanList
-
-    if newIban in iban_list:
-        LOGGER.info("IBAN already exists for the user.")
-        return
-
-    iban_list.append(newIban)
+    iban_list = user.ibanSet
+    iban_list.add(newIban)
 
     response = _get_user_table().update_item(
         Key={"userId": userId},
-        UpdateExpression="SET ibanList = :updated_list",
+        UpdateExpression="SET ibanSet = :updated_list",
         ExpressionAttributeValues={":updated_list": iban_list},
         ReturnValues="UPDATED_NEW",
     )

--- a/tests/user/test_user_persistence.py
+++ b/tests/user/test_user_persistence.py
@@ -13,7 +13,7 @@ from personal_finances.user.user_auth_exceptions import (
     UserNotFound,
     InvalidIban,
     InvalidDynamoResponse,
-    ConditionalCheckFailedException
+    UserIdNotInDatabase
 )
 
 
@@ -182,9 +182,9 @@ def test_get_user_ibans(
         (
             "unknownuser",
             "DE89370400440532013000",
-            ConditionalCheckFailedException,
+            UserIdNotInDatabase,
             None,
-            ConditionalCheckFailedException,
+            UserIdNotInDatabase,
         ),
         # invalid IBAN
         (

--- a/tests/user/test_user_persistence.py
+++ b/tests/user/test_user_persistence.py
@@ -107,7 +107,7 @@ def test_get_user_password(
 
 
 @pytest.mark.parametrize(
-    "userId, get_update_response, expected_result, expected_exception",
+    "userId, get_item_response, expected_result, expected_exception",
     [
         # User with IBANs
         (
@@ -142,19 +142,33 @@ def test_get_user_password(
             None,
             UserNotFound,
         ),
+        # Invalid DynamoDB response (missing 'password')
+        (
+            "testuser",
+            {"Item": {"userId": "testuser", "ibanSet": {"DE89370400440532013000"}}},
+            None,
+            InvalidDynamoResponse,
+        ),
+        # Invalid DynamoDB response (missing 'ibanList')
+        (
+            "testuser",
+            {"Item": {"userId": "testuser", "password": "password"}},
+            None,
+            InvalidDynamoResponse,
+        ),
     ],
 )
 def test_get_user_ibans(
     userId: str,
-    get_update_response: str,
+    get_item_response: str,
     expected_result: set[str],
     expected_exception: type[Exception],
     mock_dynamodb_table: Mock,
 ) -> None:
-    if isinstance(get_update_response, Exception):
-        mock_dynamodb_table.get_item.side_effect = get_update_response
+    if isinstance(get_item_response, Exception):
+        mock_dynamodb_table.get_item.side_effect = get_item_response
     else:
-        mock_dynamodb_table.get_item.return_value = get_update_response
+        mock_dynamodb_table.get_item.return_value = get_item_response
 
     if expected_exception:
         with pytest.raises(expected_exception):


### PR DESCRIPTION
Changes:
- **user_persistence.py** - variabes _ibanList: List[str]_ changed to _ibanSet: set[str]_
- **user_persistence.py** - removed checking for existent iban on _update_user_iban_ function
- **test_user_persistence.py** - variabes _ibanList: List[str]_ changed to _ibanSet: set[str]_
- **test_user_persistence.py** - On _test_update_user_iban_edge_cases_ function, instead of calling _mock_dynamodb_table.update_item.assert_not_called()_ at the end (for the duplicated iban addiction case), exchanged to the _mock_dynamodb_table.update_item.assert_called()_ on the last else (_expected_exception_ is _None_)